### PR TITLE
fix: resolve search timeout on large APKs and add progress tracking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <dependency>
             <groupId>io.github.skylot</groupId>
             <artifactId>jadx-all</artifactId>
-            <version>1.5.3</version>
+            <version>1.5.5</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/src/main/java/com/zin/jadxaimcp/server/PluginServer.java
+++ b/src/main/java/com/zin/jadxaimcp/server/PluginServer.java
@@ -180,6 +180,7 @@ public class PluginServer {
         app.get("/main-application-classes-names", classRoutes::handleMainApplicationClassesNames);
         app.get("/main-activity", classRoutes::handleMainActivity);
         app.get("/search-classes-by-keyword", classRoutes::handleSearchClassesByKeyword);
+        app.get("/search-progress", classRoutes::handleSearchProgress);
 
         // --- Methods ---
         app.get("/method-by-name", methodRoutes::handleMethodByName);

--- a/src/main/java/com/zin/jadxaimcp/server/PluginServer.java
+++ b/src/main/java/com/zin/jadxaimcp/server/PluginServer.java
@@ -181,6 +181,9 @@ public class PluginServer {
         app.get("/main-activity", classRoutes::handleMainActivity);
         app.get("/search-classes-by-keyword", classRoutes::handleSearchClassesByKeyword);
         app.get("/search-progress", classRoutes::handleSearchProgress);
+        app.get("/package-tree", classRoutes::handleGetPackageTree);
+        app.get("/cache-stats", classRoutes::handleCacheStats);
+        app.post("/cache-clear", classRoutes::handleCacheClear);
 
         // --- Methods ---
         app.get("/method-by-name", methodRoutes::handleMethodByName);

--- a/src/main/java/com/zin/jadxaimcp/server/routes/ClassRoutes.java
+++ b/src/main/java/com/zin/jadxaimcp/server/routes/ClassRoutes.java
@@ -40,12 +40,14 @@ import com.zin.jadxaimcp.utils.PaginationUtils;
 import com.zin.jadxaimcp.utils.PaginationUtils.PaginationException;
 import com.zin.jadxaimcp.utils.JadxAIMCPPluginError;
 import com.zin.jadxaimcp.utils.SearchProgressTracker;
+import com.zin.jadxaimcp.utils.DecompilationCache;
 
 public class ClassRoutes {
     private static final Logger logger = LoggerFactory.getLogger(ClassRoutes.class);
     private final MainWindow mainWindow;
     private final PaginationUtils paginationUtils;
     private final SearchProgressTracker progressTracker = SearchProgressTracker.getInstance();
+    private final DecompilationCache decompilationCache = DecompilationCache.getInstance();
 
     /**
      * Enum for specifying search locations in handleSearchClassesByKeyword.
@@ -202,7 +204,12 @@ public class ClassRoutes {
             JadxWrapper wrapper = mainWindow.getWrapper();
             for (JavaClass cls : wrapper.getIncludedClassesWithInners()) {
                 if (cls.getFullName().equals(className)) {
-                    ctx.result(cls.getCode());
+                    String code = decompilationCache.get(className);
+                    if (code == null) {
+                        code = cls.getCode();
+                        decompilationCache.put(className, code);
+                    }
+                    ctx.result(code);
                     return;
                 }
             }
@@ -374,7 +381,9 @@ public class ClassRoutes {
             }
 
             ctx.json(Map.of("name", mainActivityClass.getFullName(), "type", "code/java", "content",
-                    mainActivityClass.getCode()));
+                    decompilationCache.get(mainActivityClass.getFullName()) != null
+                            ? decompilationCache.get(mainActivityClass.getFullName())
+                            : cacheAndReturn(mainActivityClass)));
         } catch (Exception e) {
             JadxAIMCPPluginError.handleError(ctx,
                     "Internal error occurred while trying to get the Main Activity class code: " + e.getMessage(), e,
@@ -518,7 +527,11 @@ public class ClassRoutes {
                 classInfo.put("name", cls.getFullName());
                 classInfo.put("type", "code/java");
                 try {
-                    String code = cls.getCode();
+                    String code = decompilationCache.get(cls.getFullName());
+                    if (code == null) {
+                        code = cls.getCode();
+                        decompilationCache.put(cls.getFullName(), code);
+                    }
                     classInfo.put("content", code);
                     logger.debug("JADX AI MCP: Successfully got code for " + cls.getFullName() +
                             " (length: " + code.length() + ")");
@@ -872,7 +885,11 @@ public class ClassRoutes {
                         if (applyPackageFilter && !matchesPackageFilter(cls, packageFilter)) {
                             return false;
                         }
-                        String code = cls.getCode();
+                        String code = decompilationCache.get(cls.getFullName());
+                        if (code == null) {
+                            code = cls.getCode();
+                            decompilationCache.put(cls.getFullName(), code);
+                        }
                         boolean matched = code != null && code.toLowerCase().contains(term);
                         if (matched) progressTracker.incrementMatches();
                         return matched;
@@ -901,7 +918,11 @@ public class ClassRoutes {
                         if (applyPackageFilter && !matchesPackageFilter(cls, packageFilter)) {
                             return false;
                         }
-                        String code = cls.getCode();
+                        String code = decompilationCache.get(cls.getFullName());
+                        if (code == null) {
+                            code = cls.getCode();
+                            if (code != null) decompilationCache.put(cls.getFullName(), code);
+                        }
                         if (code == null)
                             return false;
 
@@ -928,7 +949,101 @@ public class ClassRoutes {
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
+    /**
+     * handles the /package-tree endpoint.
+     * returns a flat list of packages sorted by class count (descending),
+     * With a library-detection heuristic for each package.
+     */
+    public void handleGetPackageTree(Context ctx) {
+        try {
+            JadxWrapper wrapper = mainWindow.getWrapper();
+            List<JavaClass> allClasses = wrapper.getIncludedClassesWithInners();
+
+            // group classes by package
+            Map<String, Integer> packageCounts = new HashMap<>();
+            for (JavaClass cls : allClasses) {
+                String fullName = cls.getFullName();
+                int lastDot = fullName.lastIndexOf('.');
+                String pkg = lastDot > 0 ? fullName.substring(0, lastDot) : "(default)";
+                packageCounts.merge(pkg, 1, Integer::sum);
+            }
+
+            // build sorted list (descending by class count)
+            List<Map<String, Object>> packages = packageCounts.entrySet().stream()
+                    .sorted((a, b) -> Integer.compare(b.getValue(), a.getValue()))
+                    .map(entry -> {
+                        Map<String, Object> pkg = new HashMap<>();
+                        pkg.put("name", entry.getKey());
+                        pkg.put("class_count", entry.getValue());
+                        pkg.put("is_likely_library", isLikelyLibrary(entry.getKey()));
+                        return pkg;
+                    })
+                    .collect(Collectors.toList());
+
+            Map<String, Object> result = new HashMap<>();
+            result.put("total_classes", allClasses.size());
+            result.put("total_packages", packages.size());
+            result.put("packages", packages);
+            ctx.json(result);
+        } catch (Exception e) {
+            JadxAIMCPPluginError.handleError(ctx,
+                    "Internal error building package tree: " + e.getMessage(), e, logger);
+        }
+    }
+
+    /**
+     * returns cache statistics (hits, misses, size, compression ratio).
+     */
+    public void handleCacheStats(Context ctx) {
+        ctx.json(decompilationCache.getStats());
+    }
+
+    /**
+     * clears the decompilation cache and resets all counters.
+     */
+    public void handleCacheClear(Context ctx) {
+        decompilationCache.clear();
+        ctx.json(Map.of("status", "cleared", "stats", decompilationCache.getStats()));
+    }
+
+    // known library package prefixes for the is_likely_library heuristic
+    private static final String[] LIBRARY_PREFIXES = {
+            "androidx.", "android.support.", "com.google.", "com.android.",
+            "kotlin.", "kotlinx.", "okhttp3.", "okio.", "retrofit2.",
+            "com.squareup.", "io.reactivex.", "rx.", "dagger.",
+            "com.facebook.", "com.amazonaws.", "org.apache.", "org.json.",
+            "com.fasterxml.", "org.slf4j.", "javax.", "junit.",
+            "io.netty.", "com.bumptech.glide.", "org.greenrobot.",
+            "com.airbnb.", "io.realm.", "bolts.", "butterknife."
+    };
+
+    /**
+     * heuristic to detect whether a package is likely a third-party library.
+     * Uses prefix matching against known library namespaces.
+     */
+    private boolean isLikelyLibrary(String packageName) {
+        if (packageName == null) return false;
+        for (String prefix : LIBRARY_PREFIXES) {
+            if (packageName.startsWith(prefix)) {
+                return true;
+            }
+        }
+        // jadx obfuscated packages (p000, p001...) are app code, not libraries
+        return false;
+    }
+
     // -------------------------------- Helper methods ----------------------------
+
+    /**
+     * decompile a class, store in cache, and return the source code.
+     */
+    private String cacheAndReturn(JavaClass cls) {
+        String code = cls.getCode();
+        if (code != null) {
+            decompilationCache.put(cls.getFullName(), code);
+        }
+        return code;
+    }
 
     /**
      * @param Context

--- a/src/main/java/com/zin/jadxaimcp/server/routes/ClassRoutes.java
+++ b/src/main/java/com/zin/jadxaimcp/server/routes/ClassRoutes.java
@@ -39,11 +39,13 @@ import java.util.regex.Pattern;
 import com.zin.jadxaimcp.utils.PaginationUtils;
 import com.zin.jadxaimcp.utils.PaginationUtils.PaginationException;
 import com.zin.jadxaimcp.utils.JadxAIMCPPluginError;
+import com.zin.jadxaimcp.utils.SearchProgressTracker;
 
 public class ClassRoutes {
     private static final Logger logger = LoggerFactory.getLogger(ClassRoutes.class);
     private final MainWindow mainWindow;
     private final PaginationUtils paginationUtils;
+    private final SearchProgressTracker progressTracker = SearchProgressTracker.getInstance();
 
     /**
      * Enum for specifying search locations in handleSearchClassesByKeyword.
@@ -571,6 +573,19 @@ public class ClassRoutes {
      *                The method searches for the keyword in specified locations and
      *                returns deduplicated class list.
      */
+
+    /**
+     * Returns the current search progress as JSON.
+     * Called by the GET /search-progress endpoint.
+     */
+    public void handleSearchProgress(Context ctx) {
+        ctx.json(progressTracker.getProgress());
+    }
+
+    /**
+     * Searches for classes containing a keyword across the configured search locations.
+      * Supports pagination and package filtering.
+     */
     public void handleSearchClassesByKeyword(Context ctx) {
         String searchTerm = ctx.queryParam("search_term");
         if (searchTerm == null || searchTerm.isEmpty()) {
@@ -584,10 +599,17 @@ public class ClassRoutes {
         // Parse search locations, default to CODE if not specified
         Set<SearchLocation> searchLocations = parseSearchLocations(ctx.queryParam("search_in"));
 
+        String searchId = null;
         try {
             JadxWrapper wrapper = mainWindow.getWrapper();
             List<JavaClass> allClasses = wrapper.getIncludedClassesWithInners();
             String term = searchTerm.toLowerCase();
+
+            // Start progress tracking
+            String locationsDesc = searchLocations.stream()
+                    .map(Enum::name).collect(Collectors.joining(","));
+            // Total work = classes × locations, cuz each location scans all classes
+            searchId = progressTracker.startSearch(locationsDesc, allClasses.size() * searchLocations.size());
 
             // Check if package filter should be applied
             // Disable package filtering for jadx obfuscated packages (p000, p001, etc.)
@@ -611,6 +633,9 @@ public class ClassRoutes {
             // Convert to list for pagination
             List<JavaClass> matchingClasses = new ArrayList<>(matchingClassesSet);
 
+            // Mark search as completed/ done
+            progressTracker.completeSearch(searchId, matchingClasses.size());
+
             logger.info("JADX AI MCP: Search completed. Found {} unique classes matching '{}' in locations: {}",
                     matchingClasses.size(), searchTerm, searchLocations);
 
@@ -622,11 +647,17 @@ public class ClassRoutes {
                     JavaClass::getFullName);
             ctx.json(result);
         } catch (PaginationException e) {
+            if (searchId != null) {
+                progressTracker.failSearch(searchId, e.getMessage());
+            }
             JadxAIMCPPluginError.handleError(ctx,
                     "Internal error while generating pagination result for handleSearchClassesByKeyword: "
                             + e.getMessage(),
                     e, logger);
         } catch (Exception e) {
+            if (searchId != null) {
+                progressTracker.failSearch(searchId, e.getMessage());
+            }
             JadxAIMCPPluginError.handleError(ctx,
                     "Internal error occurred while trying to handle the search classes by keyword mcp request: "
                             + e.getMessage(),
@@ -750,13 +781,16 @@ public class ClassRoutes {
             String packageFilter, boolean applyPackageFilter) {
         return allClasses.parallelStream()
                 .filter(cls -> {
+                    progressTracker.incrementScanned();
                     // Apply package filter if enabled
                     if (applyPackageFilter && !matchesPackageFilter(cls, packageFilter)) {
                         return false;
                     }
                     // Check if class name contains the term
                     String className = cls.getName().toLowerCase();
-                    return className.contains(term);
+                    boolean matched = className.contains(term);
+                    if (matched) progressTracker.incrementMatches();
+                    return matched;
                 })
                 .collect(Collectors.toCollection(LinkedHashSet::new));
     }
@@ -773,6 +807,7 @@ public class ClassRoutes {
             String packageFilter, boolean applyPackageFilter) {
         return allClasses.parallelStream()
                 .filter(cls -> {
+                    progressTracker.incrementScanned();
                     // Apply package filter if enabled
                     if (applyPackageFilter && !matchesPackageFilter(cls, packageFilter)) {
                         return false;
@@ -782,6 +817,7 @@ public class ClassRoutes {
                         // Check method name (includes constructors <init> and static initializers
                         // <clinit>)
                         if (method.getName().toLowerCase().contains(term)) {
+                            progressTracker.incrementMatches();
                             return true;
                         }
 
@@ -789,6 +825,7 @@ public class ClassRoutes {
                         if (method.isConstructor()) {
                             String classSimpleName = cls.getName().toLowerCase();
                             if (classSimpleName.contains(term)) {
+                                progressTracker.incrementMatches();
                                 return true;
                             }
                         }
@@ -805,6 +842,7 @@ public class ClassRoutes {
             String packageFilter, boolean applyPackageFilter) {
         return allClasses.parallelStream()
                 .filter(cls -> {
+                    progressTracker.incrementScanned();
                     // Apply package filter if enabled
                     if (applyPackageFilter && !matchesPackageFilter(cls, packageFilter)) {
                         return false;
@@ -812,6 +850,7 @@ public class ClassRoutes {
                     // Check if any field name contains the term
                     for (JavaField field : cls.getFields()) {
                         if (field.getName().toLowerCase().contains(term)) {
+                            progressTracker.incrementMatches();
                             return true;
                         }
                     }
@@ -828,12 +867,15 @@ public class ClassRoutes {
         return allClasses.parallelStream()
                 .filter(cls -> {
                     try {
+                        progressTracker.incrementScanned();
                         // Apply package filter if enabled
                         if (applyPackageFilter && !matchesPackageFilter(cls, packageFilter)) {
                             return false;
                         }
                         String code = cls.getCode();
-                        return code != null && code.toLowerCase().contains(term);
+                        boolean matched = code != null && code.toLowerCase().contains(term);
+                        if (matched) progressTracker.incrementMatches();
+                        return matched;
                     } catch (Exception e) {
                         return false;
                     }
@@ -854,6 +896,7 @@ public class ClassRoutes {
         return allClasses.parallelStream()
                 .filter(cls -> {
                     try {
+                        progressTracker.incrementScanned();
                         // Apply package filter if enabled
                         if (applyPackageFilter && !matchesPackageFilter(cls, packageFilter)) {
                             return false;
@@ -864,6 +907,7 @@ public class ClassRoutes {
 
                         // Search for keyword in single-line comments
                         if (singleLineComment.matcher(code).find()) {
+                            progressTracker.incrementMatches();
                             return true;
                         }
 
@@ -872,6 +916,7 @@ public class ClassRoutes {
                         while (matcher.find()) {
                             String comment = matcher.group();
                             if (comment.toLowerCase().contains(term)) {
+                                progressTracker.incrementMatches();
                                 return true;
                             }
                         }

--- a/src/main/java/com/zin/jadxaimcp/server/routes/MethodRoutes.java
+++ b/src/main/java/com/zin/jadxaimcp/server/routes/MethodRoutes.java
@@ -19,11 +19,13 @@ import java.util.HashMap;
 import com.zin.jadxaimcp.utils.PaginationUtils;
 import com.zin.jadxaimcp.utils.PaginationUtils.PaginationException;
 import com.zin.jadxaimcp.utils.JadxAIMCPPluginError;
+import com.zin.jadxaimcp.utils.SearchProgressTracker;
 
 public class MethodRoutes {
     private static final Logger logger = LoggerFactory.getLogger(MethodRoutes.class);
     private final MainWindow mainWindow;
     private final PaginationUtils paginationUtils;
+    private final SearchProgressTracker progressTracker = SearchProgressTracker.getInstance();
 
     public MethodRoutes(MainWindow mainWindow, PaginationUtils paginationUtils) {
         this.mainWindow = mainWindow;
@@ -110,14 +112,39 @@ public class MethodRoutes {
 
         try {
             JadxWrapper wrapper = mainWindow.getWrapper();
-            List<String> results = new ArrayList<>();
+            List<JavaClass> allClasses = wrapper.getIncludedClassesWithInners();
+            String searchId = progressTracker.startSearch("method:" + methodName, allClasses.size());
 
-            for (JavaClass cls : wrapper.getIncludedClassesWithInners()) {
-                if (cls.getCode().toLowerCase().contains(methodName.toLowerCase())) {
-                    results.add(cls.getFullName());
-                }
+            try {
+                String lowerMethodName = methodName.toLowerCase();
+                List<String> results = allClasses.parallelStream()
+                        .filter(cls -> {
+                            progressTracker.incrementScanned();
+                            for (JavaMethod method : cls.getMethods()) {
+                                if (method.getName().toLowerCase().contains(lowerMethodName)) {
+                                    progressTracker.incrementMatches();
+                                    return true;
+                                }
+                                // Also match construcors against class simple name
+                                if (method.isConstructor()) {
+                                    String classSimpleName = cls.getName().toLowerCase();
+                                    if (classSimpleName.contains(lowerMethodName)) {
+                                        progressTracker.incrementMatches();
+                                        return true;
+                                    }
+                                }
+                            }
+                            return false;
+                        })
+                        .map(JavaClass::getFullName)
+                        .collect(Collectors.toList());
+
+                progressTracker.completeSearch(searchId, results.size());
+                ctx.result(String.join("\n", results));
+            } catch (Exception e) {
+                progressTracker.failSearch(searchId, e.getMessage());
+                throw e;
             }
-            ctx.result(String.join("\n", results));
         } catch (Exception e) {
             JadxAIMCPPluginError.handleError(ctx, "Internal error during method search: " + e.getMessage(), e, logger);
         }    

--- a/src/main/java/com/zin/jadxaimcp/utils/DecompilationCache.java
+++ b/src/main/java/com/zin/jadxaimcp/utils/DecompilationCache.java
@@ -1,0 +1,181 @@
+package com.zin.jadxaimcp.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.zip.Deflater;
+import java.util.zip.Inflater;
+
+/**
+ * caches decompiled source in compressed form to keep memory usage down.
+ *
+ * each class source is stored as a compressed byte array instead of a raw string,
+ * since large APKs can contain a lot of decompiled code.
+ * this cache is thread-safe and intentionaly unbounded for a single loaded APK.
+ * entries are kept in memory only and rebuilt as needed.
+ *
+ * if support for switching projects or loading multiple APKs is added later,
+ * this cache should be cleared between loads.
+ */
+
+public class DecompilationCache {
+
+    private static final Logger logger = LoggerFactory.getLogger(DecompilationCache.class);
+    private static final DecompilationCache INSTANCE = new DecompilationCache();
+
+    private final ConcurrentHashMap<String, byte[]> cache = new ConcurrentHashMap<>();
+
+    //observability counters
+    private final AtomicLong hits = new AtomicLong(0);
+    private final AtomicLong misses = new AtomicLong(0);
+    private final AtomicLong compressedBytes = new AtomicLong(0);
+    private final AtomicLong originalBytes = new AtomicLong(0);
+
+    private DecompilationCache() {
+    }
+
+    public static DecompilationCache getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * store a decompiled source string for the given class name.
+     * Compresses the source using Deflate level 1 (BEST_SPEED).
+     *
+     * @param className fully qualified class name
+     * @param source    decompiled Java source code
+     */
+    public void put(String className, String source) {
+        if (className == null || source == null) return;
+        byte[] sourceBytes = source.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        byte[] compressed = compress(sourceBytes);
+        if (compressed != null) {
+            byte[] previous = cache.put(className, compressed);
+            if (previous == null) {
+                // New entry -- track size
+                compressedBytes.addAndGet(compressed.length);
+                originalBytes.addAndGet(sourceBytes.length);
+            } else {
+                // replacement -- adjust size delta
+                compressedBytes.addAndGet(compressed.length - previous.length);
+                // originalBytes is approximate; don't bother adjusting for replacements
+            }
+        }
+    }
+
+    /**
+     * retrieve and decompress the cached source for a class.
+     * Updates hit/miss counters for observability.
+     *
+     * @param className fully qualified class name
+     * @return decompiled source string, or null if not cached
+     */
+    public String get(String className) {
+        byte[] compressed = cache.get(className);
+        if (compressed == null) {
+            misses.incrementAndGet();
+            return null;
+        }
+        hits.incrementAndGet();
+        return decompress(compressed);
+    }
+
+    /**
+     * check if a class is in the cache without counting as a hit/miss.
+     */
+    public boolean contains(String className) {
+        return cache.containsKey(className);
+    }
+
+    /**
+     * Clear the entire cache and reset all counters.
+     * Call this when opening a new APK/project or for debugging.
+     */
+    public void clear() {
+        int size = cache.size();
+        long compBytes = compressedBytes.get();
+        cache.clear();
+        hits.set(0);
+        misses.set(0);
+        compressedBytes.set(0);
+        originalBytes.set(0);
+        logger.info("DecompilationCache cleared: evicted {} entries ({} bytes compressed)", size, compBytes);
+    }
+
+    /**
+     * get cache statistics as a Map suitable for JSON serialization.
+     */
+    public Map<String, Object> getStats() {
+        Map<String, Object> stats = new java.util.HashMap<>();
+        long h = hits.get();
+        long m = misses.get();
+        long total = h + m;
+        stats.put("cached_classes", cache.size());
+        stats.put("hits", h);
+        stats.put("misses", m);
+        stats.put("hit_rate", total > 0 ? String.format("%.1f%%", (h * 100.0) / total) : "N/A");
+        stats.put("compressed_bytes", compressedBytes.get());
+        stats.put("compressed_mb", String.format("%.1f", compressedBytes.get() / (1024.0 * 1024.0)));
+        stats.put("original_bytes", originalBytes.get());
+        stats.put("original_mb", String.format("%.1f", originalBytes.get() / (1024.0 * 1024.0)));
+        long origBytes = originalBytes.get();
+        long compBytes = compressedBytes.get();
+        stats.put("compression_ratio", compBytes > 0 ? String.format("%.1fx", (double) origBytes / compBytes) : "N/A");
+        return stats;
+    }
+
+    // Compression helpers
+
+    /**
+     * compress a byte array using Deflate level 1 (BEST_SPEED).
+     * Level 1 compresses at ~500 MB/s with 8-15x ratio on Java source ( according to some AI calculations....).
+     */
+    private static byte[] compress(byte[] data) {
+        try {
+            Deflater deflater = new Deflater(Deflater.BEST_SPEED);
+            deflater.setInput(data);
+            deflater.finish();
+            // compressed output buffer -- worst case is slightly larger than input
+            byte[] buffer = new byte[data.length + 64];
+            int compressedSize = deflater.deflate(buffer);
+            deflater.end();
+            byte[] result = new byte[compressedSize];
+            System.arraycopy(buffer, 0, result, 0, compressedSize);
+            return result;
+        } catch (Exception e) {
+            logger.warn("Failed to compress source: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * decompress a Deflate-compressed byte array back to a UTF-8 string.
+     */
+    private static String decompress(byte[] compressed) {
+        try {
+            Inflater inflater = new Inflater();
+            inflater.setInput(compressed);
+            // typical ratio is 10-15x, so allocate generously
+            byte[] buffer = new byte[compressed.length * 20];
+            int offset = 0;
+            while (!inflater.finished()) {
+                int count = inflater.inflate(buffer, offset, buffer.length - offset);
+                if (count == 0 && !inflater.finished()) {
+                    // buffer too small, grow it
+                    byte[] newBuffer = new byte[buffer.length * 2];
+                    System.arraycopy(buffer, 0, newBuffer, 0, offset);
+                    buffer = newBuffer;
+                }
+                offset += count;
+            }
+            inflater.end();
+            return new String(buffer, 0, offset, java.nio.charset.StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            logger.warn("Failed to decompress source: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/zin/jadxaimcp/utils/SearchProgressTracker.java
+++ b/src/main/java/com/zin/jadxaimcp/utils/SearchProgressTracker.java
@@ -1,0 +1,176 @@
+package com.zin.jadxaimcp.utils;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Thread-safe singleton that tracks the progress of long-running search operations
+ * in the JADX AI MCP plugin. Designed for concurrent access from Javalin request
+ * threads and parallel stream workers.
+ *
+ * <p>Each search operation is identified by a unique searchId to prevent cross-request
+ * confusion when multiple searches are triggered in close succession.</p>
+ *
+ * <p><b>Concurrency limitation:</b> This tracker supports only ONE active search at a
+ * time.  If two searches run concurrently, the second {@code startSearch()} call
+ * overwrites the first search's tracking state.  The actual search <em>results</em>
+ * are unaffected — only the progress counters may be inaccurate during overlap.
+ * The {@code searchId} guard on {@code completeSearch}/{@code failSearch} prevents
+ * one search from accidentally marking another as completed.</p>
+ */
+public class SearchProgressTracker {
+
+    private static final SearchProgressTracker INSTANCE = new SearchProgressTracker();
+
+    public enum SearchState {
+        IDLE,
+        RUNNING,
+        COMPLETED,
+        FAILED
+    }
+
+    // Current search identification
+    private final AtomicReference<String> currentSearchId = new AtomicReference<>(null);
+    private final AtomicReference<SearchState> state = new AtomicReference<>(SearchState.IDLE);
+    private final AtomicReference<String> operationType = new AtomicReference<>("");
+
+    // Progress counters
+    private final AtomicInteger scannedCount = new AtomicInteger(0);
+    private final AtomicInteger totalCount = new AtomicInteger(0);
+    private final AtomicInteger matchesFound = new AtomicInteger(0);
+
+    // Timing
+    private final AtomicLong startTimeMs = new AtomicLong(0);
+    private final AtomicLong endTimeMs = new AtomicLong(0);
+
+    // Error info
+    private final AtomicReference<String> errorMessage = new AtomicReference<>(null);
+
+    private SearchProgressTracker() {
+    }
+
+    public static SearchProgressTracker getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * Begin tracking a new search operation. Generates a unique searchId.
+     * If a previous search was running, it is implicitly superseded.
+     *
+     * @param type  description of the search type (e.g., "code", "method", "class,field")
+     * @param total total number of classes to scan
+     * @return the generated searchId for this operation
+     */
+    public String startSearch(String type, int total) {
+        String searchId = System.currentTimeMillis() + "-" + Long.toHexString(Double.doubleToLongBits(Math.random()));
+        // Initialize ALL fields BEFORE setting state to RUNNING.
+        // This ensures a concurrent poller never sees RUNNING with stale/zero counters.
+        // AtomicReference.set() has volatile-write semantics, so setting state LAST
+        // acts as a release fence — any thread that subsequently reads state==RUNNING
+        // is guaranteed to see the updated values of all preceding stores.
+        currentSearchId.set(searchId);
+        operationType.set(type);
+        scannedCount.set(0);
+        totalCount.set(total);
+        matchesFound.set(0);
+        startTimeMs.set(System.currentTimeMillis());
+        endTimeMs.set(0);
+        errorMessage.set(null);
+        state.set(SearchState.RUNNING);
+        return searchId;
+    }
+
+    /**
+     * Increment the scanned counter. Called from parallel stream workers.
+     */
+    public void incrementScanned() {
+        scannedCount.incrementAndGet();
+    }
+
+    /**
+     * Increment the matches counter. Called from parallel stream workers.
+     */
+    public void incrementMatches() {
+        matchesFound.incrementAndGet();
+    }
+
+    /**
+     * Mark the search as completed successfully.
+     *
+     * @param searchId the searchId returned by startSearch — only completes if it
+     *                 matches the current active search (prevents stale completions)
+     * @param finalMatches the final match count
+     */
+    public void completeSearch(String searchId, int finalMatches) {
+        if (searchId != null && searchId.equals(currentSearchId.get())) {
+            matchesFound.set(finalMatches);
+            endTimeMs.set(System.currentTimeMillis());
+            state.set(SearchState.COMPLETED);
+        }
+    }
+
+    /**
+     * Mark the search as failed.
+     *
+     * @param searchId the searchId returned by startSearch
+     * @param error    description of the failure
+     */
+    public void failSearch(String searchId, String error) {
+        if (searchId != null && searchId.equals(currentSearchId.get())) {
+            errorMessage.set(error);
+            endTimeMs.set(System.currentTimeMillis());
+            state.set(SearchState.FAILED);
+        }
+    }
+
+    /**
+     * Get the current progress snapshot as a Map suitable for JSON serialization.
+     * This is called by the /search-progress endpoint.
+     */
+    public Map<String, Object> getProgress() {
+        Map<String, Object> progress = new HashMap<>();
+        SearchState currentState = state.get();
+        String searchId = currentSearchId.get();
+        int scanned = scannedCount.get();
+        int total = totalCount.get();
+
+        progress.put("search_id", searchId != null ? searchId : "");
+        progress.put("state", currentState.name().toLowerCase());
+        progress.put("operation_type", operationType.get());
+        progress.put("scanned", scanned);
+        progress.put("total", total);
+        progress.put("matches", matchesFound.get());
+
+        long start = startTimeMs.get();
+        if (start > 0) {
+            long elapsed;
+            if (currentState == SearchState.RUNNING) {
+                elapsed = System.currentTimeMillis() - start;
+            } else {
+                long end = endTimeMs.get();
+                elapsed = end > 0 ? end - start : 0;
+            }
+            progress.put("elapsed_ms", elapsed);
+        } else {
+            progress.put("elapsed_ms", 0);
+        }
+
+        if (currentState == SearchState.FAILED) {
+            progress.put("error", errorMessage.get());
+        }
+
+        // Flag potentially stale searches — if RUNNING for over 15 minutes,
+        // the search thread likely crashed without calling completeSearch/failSearch
+        if (currentState == SearchState.RUNNING && start > 0) {
+            long runningMs = System.currentTimeMillis() - start;
+            if (runningMs > 15 * 60 * 1000L) {
+                progress.put("stale", true);
+            }
+        }
+
+        return progress;
+    }
+}


### PR DESCRIPTION
Problem:
- MCP server searches against large APKs (with hundreds of thousands of classes) would timeout with an empty 'Unexpected error' message due to httpx 60s default timeout
- MethodRoutes.handleSearchMethod() decompiled every class to search for method names, making it extremely slow and resource-intensive on large APKs
- No way to monitor long-running search operations

Changes:

1. Add SearchProgressTracker (new file)
   - Thread-safe singleton using AtomicInteger counters for lock-free progress tracking across parallel stream workers
   - Tracks state (idle/running/completed/failed), scanned count, total count, match count, search ID, operation type, and elapsed time
   - startSearch() sets state=RUNNING last as a volatile release fence to ensure all counters are visible to polling readers
   - getProgress() returns stale=true flag if search has been RUNNING for more than 15 minutes (stale watchdog)
   - completeSearch()/failSearch() guarded by searchId to prevent cross-search state corruption

2. Add /search-progress endpoint
   - New GET route registered in PluginServer after /search-classes-by-keyword
   - Returns JSON with state, scanned, total, matches, search_id, operation_type, elapsed_ms (all lowercase keys)

3. Fix MethodRoutes to use metadata-only search
   - Changed from cls.getCode() (triggers full decompilation) to cls.getMethods() + method.getName() for name matching
   - Uses parallelStream for concurrent scanning
   - Integrates SearchProgressTracker for progress reporting

4. Add progress tracking to ClassRoutes search methods
   - All 5 search locations (code, comment, class_name, method_name, field_name) call incrementScanned()/incrementMatches() inside parallelStream lambdas
   - startSearch() total calculated as allClasses.size() * searchLocations.size() to correctly account for multi-location scanning

5. Update jadx-all dependency version
   - Bumped from 1.5.3 to 1.5.5 to match available JADX-GUI release