### PR TITLE
docs: fix dependency typos

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Thank you for considering contributing to the project! We welcome contributions 
    # Create a new branch
    git checkout -b your-feature-branch
 
-   # Add jadx jar file as dependecy in your local maven repository
+   # Add jadx jar file as dependency in your local maven repository
    mvn install:install-file -Dfile=path/to/jadx-<version>-all.jar \
                          -DgroupId=io.github.skylot \
                          -DartifactId=jadx-all \

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ cd jadx-mcp-server
 # 4. This project uses uv - https://github.com/astral-sh/uv instead of pip for dependency management.
     ## a. Install uv (if you dont have it yet)
 curl -LsSf https://astral.sh/uv/install.sh | sh
-    ## b. OPTIONAL, if for any reasons, you get dependecy errors in jadx-mcp-server, Set up the environment
+    ## b. OPTIONAL, if for any reasons, you get dependency errors in jadx-mcp-server, Set up the environment
 uv venv
 source .venv/bin/activate  # or .venv\Scripts\activate on Windows
     ## c. OPTIONAL Install dependencies


### PR DESCRIPTION
## Problem
The README and contribution guide spell `dependency` as `dependecy` in setup instructions.

## Solution
Corrected both occurrences.

## Validation
- `git diff --check`

Confidence score: 85/100
Category: docs/typo
