### PR TITLE
fix: match renamed method aliases and stop 500s on binary resources

### DIFF
--- a/src/main/java/com/zin/jadxaimcp/server/routes/MethodRoutes.java
+++ b/src/main/java/com/zin/jadxaimcp/server/routes/MethodRoutes.java
@@ -19,6 +19,7 @@ import java.util.HashMap;
 import com.zin.jadxaimcp.utils.PaginationUtils;
 import com.zin.jadxaimcp.utils.PaginationUtils.PaginationException;
 import com.zin.jadxaimcp.utils.JadxAIMCPPluginError;
+import com.zin.jadxaimcp.utils.MethodSignatures;
 import com.zin.jadxaimcp.utils.SearchProgressTracker;
 
 public class MethodRoutes {
@@ -75,11 +76,8 @@ public class MethodRoutes {
                 for (JavaClass cls : wrapper.getIncludedClassesWithInners()) {
                     for (JavaMethod method : cls.getMethods()) {
                         if (method.getName().equalsIgnoreCase(methodName)) {
-                            if (methodSignature != null && !methodSignature.isEmpty()) {
-                                String shortId = method.getMethodNode().getMethodInfo().getShortId();
-                                if (!shortId.contains(methodSignature)) {
-                                    continue;
-                                }
+                            if (!MethodSignatures.matches(method, methodSignature)) {
+                                continue;
                             }
                             returnMethodResult(ctx, cls, method);
                             return;
@@ -93,11 +91,8 @@ public class MethodRoutes {
                     if (cls.getFullName().equals(className)) {
                         for (JavaMethod method : cls.getMethods()) {
                             if (method.getName().equalsIgnoreCase(methodName)) {
-                                if (methodSignature != null && !methodSignature.isEmpty()) {
-                                    String shortId = method.getMethodNode().getMethodInfo().getShortId();
-                                    if (!shortId.contains(methodSignature)) {
-                                        continue;
-                                    }
+                                if (!MethodSignatures.matches(method, methodSignature)) {
+                                    continue;
                                 }
                                 returnMethodResult(ctx, cls, method);
                                 return;

--- a/src/main/java/com/zin/jadxaimcp/server/routes/RefactoringRoutes.java
+++ b/src/main/java/com/zin/jadxaimcp/server/routes/RefactoringRoutes.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.zin.jadxaimcp.utils.JadxAIMCPPluginError;
+import com.zin.jadxaimcp.utils.MethodSignatures;
 
 public class RefactoringRoutes {
     private static final Logger logger = LoggerFactory.getLogger(RefactoringRoutes.class);
@@ -87,6 +88,7 @@ public class RefactoringRoutes {
      * 
      */
     public void handleRenameMethod(Context ctx) {
+        String className = ctx.queryParam("class_name");
         String methodName = ctx.queryParam("method_name");
         String newName = ctx.queryParam("new_name");
         String methodSignature = ctx.queryParam("method_signature");
@@ -104,30 +106,32 @@ public class RefactoringRoutes {
 
         try {
             JadxWrapper wrapper = mainWindow.getWrapper();
-            for (JavaClass cls : wrapper.getIncludedClassesWithInners()) {
-                // Fix: removed the .replace('$', '.'); from below line to
-                // prevent bug where innerclasses are discoverable
-                String clsName = cls.getFullName();
-                for (JavaMethod method : cls.getMethods()) {
-                    String fullMethodName = clsName + "." + method.getName();
-                    if (fullMethodName.equalsIgnoreCase(methodName) || method.getName().equalsIgnoreCase(methodName)) {
-                        if (methodSignature != null && !methodSignature.isEmpty()) {
-                            String shortId = method.getMethodNode().getMethodInfo().getShortId();
-                            if (!shortId.contains(methodSignature)) {
-                                continue;
-                            }
-                        }
-                        
-                        ICodeNodeRef nodeRef = method.getCodeNodeRef();
-                        NodeRenamedByUser event = new NodeRenamedByUser(nodeRef, method.getName(), newName);
-                        event.setRenameNode(method.getMethodNode());
-                        event.setResetName(newName.isEmpty());
-                        mainWindow.events().send(event);
-
-                        logger.info("Renaming method {} to {}", method.getName(), newName);
-                        ctx.json(Map.of("result", "Rename method " + method.getName() + " to " + newName));
-                        return;
+            if (className != null && !className.isEmpty()) {
+                JavaClass targetClass = null;
+                for (JavaClass cls : wrapper.getIncludedClassesWithInners()) {
+                    if (cls.getFullName().equals(className)) {
+                        targetClass = cls;
+                        break;
                     }
+                }
+
+                if (targetClass == null) {
+                    JadxAIMCPPluginError.handleError(ctx, 404, "Class " + className + " not found.", logger);
+                    return;
+                }
+
+                if (tryRenameMethodInClass(ctx, targetClass, methodName, newName, methodSignature)) {
+                    return;
+                }
+
+                JadxAIMCPPluginError.handleError(ctx, 404,
+                        "Method " + methodName + " not found in class " + className + ".", logger);
+                return;
+            }
+
+            for (JavaClass cls : wrapper.getIncludedClassesWithInners()) {
+                if (tryRenameMethodInClass(ctx, cls, methodName, newName, methodSignature)) {
+                    return;
                 }
             }
             JadxAIMCPPluginError.handleError(ctx, 404,
@@ -136,6 +140,36 @@ public class RefactoringRoutes {
             JadxAIMCPPluginError.handleError(ctx, "Internal error while trying to rename the method: " + e.getMessage(),
                     e, logger);
         }
+    }
+
+    private boolean tryRenameMethodInClass(
+            Context ctx,
+            JavaClass cls,
+            String methodName,
+            String newName,
+            String methodSignature) {
+        String clsName = cls.getFullName();
+        for (JavaMethod method : cls.getMethods()) {
+            String fullMethodName = clsName + "." + method.getName();
+            if (!(fullMethodName.equalsIgnoreCase(methodName) || method.getName().equalsIgnoreCase(methodName))) {
+                continue;
+            }
+
+            if (!MethodSignatures.matches(method, methodSignature)) {
+                continue;
+            }
+
+            ICodeNodeRef nodeRef = method.getCodeNodeRef();
+            NodeRenamedByUser event = new NodeRenamedByUser(nodeRef, method.getName(), newName);
+            event.setRenameNode(method.getMethodNode());
+            event.setResetName(newName.isEmpty());
+            mainWindow.events().send(event);
+
+            logger.info("Renaming method {}.{} to {}", clsName, method.getName(), newName);
+            ctx.json(Map.of("result", "Rename method " + clsName + "." + method.getName() + " to " + newName));
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/com/zin/jadxaimcp/server/routes/ResourceRoutes.java
+++ b/src/main/java/com/zin/jadxaimcp/server/routes/ResourceRoutes.java
@@ -147,28 +147,74 @@ public class ResourceRoutes {
 
         try {
             List<ResourceFile> resourceFiles = mainWindow.getWrapper().getResources();
-            Map<String, String> resFileContent = new HashMap<>();
+            String matchedFileName = null;
+            String matchedContent = null;
+            boolean matchedNonText = false;
 
             for (ResourceFile resFile : resourceFiles) {
-                if (resFile.getDeobfName().equals(fileName)) {
-                    resFileContent.put("file_name", resFile.getDeobfName());
-                    resFileContent.put("content", resFile.loadContent().getText().getCodeStr());
+                String deobfName = resFile.getDeobfName();
+
+                // 1) Direct top-level resource match.
+                if (fileName.equals(deobfName)) {
+                    matchedFileName = deobfName;
+                    matchedContent = safeExtractText(safeLoadContent(resFile));
+                    if (matchedContent == null) {
+                        matchedNonText = true;
+                    }
                     break;
-                } else if ("resources.arsc".equals(resFile.getDeobfName())) {
-                    for (ResContainer file : resFile.loadContent().getSubFiles()) {
-                        resFileContent.put("file_name", file.getFileName());
-                        resFileContent.put("content", file.getText().getCodeStr());
+                }
+
+                // 2) Search nested files in any container resource.
+                try {
+                    ResContainer container = resFile.loadContent();
+                    List<ResContainer> subFiles = container.getSubFiles();
+                    if (subFiles == null || subFiles.isEmpty()) {
+                        continue;
+                    }
+
+                    for (ResContainer file : subFiles) {
+                        if (!fileName.equals(file.getFileName())) {
+                            continue;
+                        }
+
+                        matchedFileName = file.getFileName();
+                        matchedContent = safeExtractText(file);
+                        if (matchedContent == null) {
+                            matchedNonText = true;
+                        }
                         break;
                     }
+                } catch (Exception e) {
+                    logger.debug("Failed to inspect subfiles for {}: {}", deobfName, e.getMessage());
                 }
-                if (!resFileContent.isEmpty()) break;
+
+                if (matchedFileName != null) {
+                    break;
+                }
             }
 
-            if (resFileContent.isEmpty()) {
+            if (matchedFileName == null) {
                 JadxAIMCPPluginError.handleError(ctx, 404, "No resource file found", logger);
                 return;
             }
-            ctx.json(Map.of("type", "resource/text", "file", resFileContent));
+
+            if (matchedContent == null) {
+                // Avoid throwing ClassCastException on non-text resources and return
+                // a stable response instead of HTTP 500 (issue #59).
+                Map<String, String> file = new HashMap<>();
+                file.put("file_name", matchedFileName);
+                file.put("content", "");
+                file.put("note", matchedNonText
+                        ? "Matched resource is not text-decodable by JADX"
+                        : "Unable to decode resource content");
+                ctx.json(Map.of("type", "resource/binary", "file", file));
+                return;
+            }
+
+            Map<String, String> file = new HashMap<>();
+            file.put("file_name", matchedFileName);
+            file.put("content", matchedContent);
+            ctx.json(Map.of("type", "resource/text", "file", file));
         } catch (Exception e) {
             JadxAIMCPPluginError.handleError(ctx, "Internal Error occured while trying to handle the handleGetResourceFile(): " + e.getMessage(), e, logger);
         }
@@ -231,6 +277,44 @@ public class ResourceRoutes {
     }
 
     // Helper methods
+
+    /**
+     * Safely extract text content from a resource container.
+     * Some resource kinds are binary-backed and can throw class cast errors when
+     * accessed as text; this helper normalizes those failures to null.
+     */
+    private String safeExtractText(ResContainer container) {
+        if (container == null) {
+            return null;
+        }
+        try {
+            if (container.getText() == null) {
+                return null;
+            }
+            return container.getText().getCodeStr();
+        } catch (ClassCastException e) {
+            logger.debug("Resource is not text-decodable: {}", e.getMessage());
+            return null;
+        } catch (Exception e) {
+            logger.debug("Failed to decode resource text: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    private ResContainer safeLoadContent(ResourceFile file) {
+        if (file == null) {
+            return null;
+        }
+        try {
+            return file.loadContent();
+        } catch (ClassCastException e) {
+            logger.debug("Resource content is not loadable as text: {}", e.getMessage());
+            return null;
+        } catch (Exception e) {
+            logger.debug("Failed to load resource content: {}", e.getMessage());
+            return null;
+        }
+    }
 
     /**
      * @param

--- a/src/main/java/com/zin/jadxaimcp/utils/MethodSignatures.java
+++ b/src/main/java/com/zin/jadxaimcp/utils/MethodSignatures.java
@@ -1,0 +1,43 @@
+package com.zin.jadxaimcp.utils;
+
+import jadx.api.JavaMethod;
+import jadx.core.dex.info.MethodInfo;
+import jadx.core.dex.nodes.MethodNode;
+
+public class MethodSignatures {
+
+    private MethodSignatures() {
+    }
+
+    /**
+     * @param method The method to test against the caller supplied signature
+     * @param methodSignature The signature/descriptor to match, e.g. '(I)V'
+     * @return boolean True when the signature identifies this method
+     *
+     * MethodInfo builds its shortId once from the original method name and never
+     * refreshes it, while JavaMethod.getName() reports the alias. After a rename the
+     * two disagree, so a signature carrying the renamed name never matches the
+     * shortId and the method looks missing. Both forms are compared here so a
+     * signature keeps resolving before and after a rename.
+     */
+    public static boolean matches(JavaMethod method, String methodSignature) {
+        if (methodSignature == null || methodSignature.isEmpty()) {
+            return true;
+        }
+
+        MethodNode methodNode = method.getMethodNode();
+        if (methodNode == null) {
+            return false;
+        }
+
+        MethodInfo methodInfo = methodNode.getMethodInfo();
+        if (methodInfo == null) {
+            return false;
+        }
+
+        if (methodInfo.getShortId().contains(methodSignature)) {
+            return true;
+        }
+        return methodInfo.makeSignature(true, true).contains(methodSignature);
+    }
+}


### PR DESCRIPTION
## Summary

Three plugin-side bug fixes that users have re-filed across both repos.

**Renamed methods stopped resolving (#106).** `MethodInfo` builds its `shortId` once, in the constructor, from the *original* method name and never refreshes it. `JavaMethod.getName()` meanwhile returns `mth.getAlias()`. Once a method is renamed the two disagree, so a caller-supplied `method_signature` is compared against a shortId that still carries the old name, never matches, and the method looks missing.

Both forms are now compared through a shared `MethodSignatures` helper, used by `rename_method` *and* `get_method_by_name` — the same staleness affected both call sites in `MethodRoutes`.

**Wrong class renamed (#103).** `rename_method` had no `class_name`, so it renamed the first name match across all classes. On R8/ProGuard output where `OooO00o` repeats in dozens of classes, the rename landed anywhere. It now accepts an optional `class_name` and scopes to that class, returning 404 if the method is not in it.

**HTTP 500 on binary resources (#105, zinja-coder/jadx-mcp-server#59).** `ResContainer.getText()` throws `ClassCastException` for containers backed by a `ResourceFile` rather than `ICodeInfo`, and the exception escaped as a 500. `get_resource_file` now returns a `resource/binary` response with an explanatory note instead.

## Notes

`MethodInfo.makeSignature(true, true)` is used rather than the `makeShortId(name, args, retType)` suggested in #106, because `JavaMethod.getArguments()` resolves class aliases and would shift the descriptor when parameter types have themselves been renamed. `makeSignature` reuses `MethodInfo`'s own raw `argTypes`.

closes #103
closes #105
closes #106
closes zinja-coder/jadx-mcp-server#59
