### PR TITLE
release: v6.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.zin.jadxaimcp</groupId>
     <artifactId>jadx-ai-mcp</artifactId>
-    <version>6.4.0</version>
+    <version>6.4.1</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>

--- a/src/main/java/com/zin/jadxaimcp/utils/JadxAIMCPBanner.java
+++ b/src/main/java/com/zin/jadxaimcp/utils/JadxAIMCPBanner.java
@@ -19,5 +19,5 @@ public class JadxAIMCPBanner {
             "\n\n" +
             "\nAuthor         -> Jafar Pathan (zinja-coder@github)" +
             "\nFor Issues     -> https://github.com/zinja-coder/jadx-ai-mcp" +
-            "\nPlugin Version -> v6.4.0";
+            "\nPlugin Version -> v6.4.1";
 }


### PR DESCRIPTION
## Summary

Version bump for the fixes merged in #109. These two lines were pushed to the #109 branch after it was opened, but GitHub never advanced the PR head, so they were not part of the merge.

- `pom.xml` - 6.4.0 → 6.4.1
- `JadxAIMCPBanner` - plugin startup banner now reports v6.4.1
