### PR TITLE
docs: sync ReadTheDocs pages with v6.4.1 behavior

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,232 +1,163 @@
 # Enhanced API Reference
 
-Comprehensive guide to all JADX-AI-MCP tools with detailed usage examples.
+This page documents the MCP tools currently exposed by `jadx_mcp_server.py`.
 
-## Table of Contents
+## Notes About Responses
 
-- [Class Analysis](#class-analysis)
-- [Search Capabilities](#search-capabilities)
-- [Resource Analysis](#resource-analysis)
-- [Cross-Reference Analysis](#cross-reference-analysis)
-- [Refactoring](#refactoring)
-- [Debugging](#debugging)
+- Some underlying plugin endpoints return raw text (`ctx.result(...)` in Java routes).
+- In those cases, the Python MCP server returns:
+  - `{"response": "<raw text>"}` (from `get_from_jadx(...)` fallback)
+- For paginated endpoints, responses generally follow:
+  - `{"type": "...", "items": [...], "pagination": {...}}`
 
 ---
 
 ## Class Analysis
 
-Tools for inspecting decompiled Java code.
-
 ### `fetch_current_class()`
+Fetches the currently selected class from JADX-GUI.
 
-Fetches the currently selected class in JADX-GUI.
-
-**Parameters:** None
-
-**Returns:**
-```json
-{
-  "className": "com.example.MainActivity",
-  "package": "com.example",
-  "source": "public class MainActivity...",
-  "type": "class"
-}
-```
-
-**Use Case:** Quick context for "Explain this class" prompts.
-
----
+### `get_selected_text()`
+Returns selected text from the current editor pane.
 
 ### `get_all_classes(offset: int = 0, count: int = 0)`
-
-Lists all classes in the APK.
-
-**Parameters:**
-- `offset` (int): Starting index
-- `count` (int): Number to return (0 = all)
-
-**Example:**
-```python
-# Get first 100 classes
-classes = await get_all_classes(offset=0, count=100)
-print(f"Total classes: {classes['pagination']['total']}")
-```
-
-**Best Practice:** Always use pagination for production APKs to avoid timeouts.
-
----
+Returns paginated list of all classes. `count=0` means no explicit limit.
 
 ### `get_class_source(class_name: str)`
+Gets full Java source for a class.
 
-Gets full source code for a specific class.
+### `get_methods_of_class(class_name: str)`
+Lists methods for a class.
 
-**Parameters:**
-- `class_name` (str): Fully qualified name
+### `get_fields_of_class(class_name: str)`
+Lists fields for a class.
 
-**Example:**
-```python
-source = await get_class_source("com.example.crypto.AES")
-```
+### `get_smali_of_class(class_name: str)`
+Gets smali for a class.
 
-**Note:** Returns cached source if already decompiled.
+### `get_main_application_classes_names()`
+Returns class names under the app package from `AndroidManifest.xml`.
 
----
+### `get_main_application_classes_code(offset: int = 0, count: int = 0)`
+Returns paginated decompiled code for classes under the app package.
 
-## Search Capabilities
+### `get_main_activity_class()`
+Returns main launcher activity class and source.
 
-### `search_classes_by_keyword(search_term: str, search_in: str = "all", package: str = "", offset: int = 0, count: int = 20)`
+### `get_package_tree()`
+Returns package summary with class counts and `is_likely_library` heuristic.
 
-Full-text search across code with advanced scoping.
+### `get_cache_stats()`
+Returns decompilation cache statistics.
 
-**Parameters:**
-- `search_term` (str): Text to find
-- `search_in` (str): Scope ("all", "code", "comments", "strings")
-- `package` (str): Restrict to specific package (e.g., "com.example")
-- `offset` (int): Start index
-- `count` (int): Max results
-
-**Example:**
-```python
-# Find hardcoded passwords in comments only
-results = await search_classes_by_keyword("password", search_in="comments", count=50)
-
-for res in results['items']:
-    print(f"Found in {res['className']}: {res['preview']}")
-```
+### `clear_cache()`
+Clears decompilation cache and resets counters.
 
 ---
+
+## Search
+
+### `get_method_by_name(class_name: str, method_name: str, method_signature: str = None)`
+Fetches one method body from a specific class.
 
 ### `search_method_by_name(method_name: str)`
+Searches method names globally.
 
-Finds methods matching a name pattern.
+Notes:
+- Matching is substring-based.
+- Current Java route returns a newline-delimited class list as text, so output can be:
+  - `{"response": "com.example.A\ncom.example.B\n..."}`
 
-**Parameters:**
-- `method_name` (str): Name or partial signature
+### `search_classes_by_keyword(search_term: str, package: str = "", search_in: str = "code", offset: int = 0, count: int = 20)`
+Searches classes by keyword with package/scope filters.
 
-**Example:**
-```python
-# Find encryption methods
-methods = await search_method_by_name("encrypt")
-```
+Valid `search_in` values:
+- `class`
+- `method`
+- `field`
+- `code`
+- `comment`
+
+You can combine scopes with commas, for example:
+- `class,method`
+- `class,method,code`
 
 ---
 
-## Resource Analysis
+## Resources
 
 ### `get_android_manifest()`
+Returns parsed/raw manifest payload from plugin endpoint.
 
-Parses AndroidManifest.xml.
+### `get_manifest_component(component_type: str, only_exported: bool = False)`
+Extracts manifest components by type.
 
-**Returns:**
-- Package name
-- Version info
-- Permissions
-- Activities/Services/Receivers/Providers
-- Raw XML
-
-**Use Case:** Security auditing permissions and exported components.
-
----
-
-### `get_manifest_component(type: str)`
-
-Get specific components from AndroidManifest.xml.
-
-**Parameters:**
-- `type` (str): "Activity", "Service", "Receiver", or "Provider"
-
----
+Valid `component_type`:
+- `activity`
+- `service`
+- `receiver`
+- `provider`
 
 ### `get_strings(offset: int = 0, count: int = 0)`
+Returns paginated strings extracted from resources.
 
-Extracts strings from `res/values/strings.xml`.
+### `get_all_resource_file_names(offset: int = 0, count: int = 0)`
+Returns paginated resource file paths.
 
-**Parameters:**
-- `offset` (int): Start index
-- `count` (int): Max strings
-
-**Use Case:** Finding API keys, URLs, or hidden messages.
+### `get_resource_file(resource_name: str)`
+Returns resource file content by path, e.g. `res/layout/activity_main.xml`.
 
 ---
 
-## Cross-Reference Analysis
+## Cross References
 
-### `get_xrefs_to_method(class_name: str, method_name: str, ...)`
+### `get_xrefs_to_class(class_name: str, offset: int = 0, count: int = 20)`
+Finds references to a class.
 
-Finds all callers of a method.
+### `get_xrefs_to_method(class_name: str, method_name: str, offset: int = 0, count: int = 20)`
+Finds references to a method (includes override-related methods in route logic).
 
-**Example:**
-```python
-# Who calls login()?
-callers = await get_xrefs_to_method(
-    "com.example.Auth", 
-    "login",
-    count=100
-)
-```
-
-**Features:**
-- Includes direct calls
-- Includes interface implementations
-- Includes super calls
+### `get_xrefs_to_field(class_name: str, field_name: str, offset: int = 0, count: int = 20)`
+Finds references to a field.
 
 ---
 
 ## Refactoring
 
 ### `rename_class(class_name: str, new_name: str)`
+Renames class.
 
-Renames class and updates references.
+### `rename_method(method_name: str, new_name: str, class_name: str = None, method_signature: str = None)`
+Renames method by name/signature.
 
-**Example:**
-```python
-# Deobfuscate
-await rename_class("a.b.c", "CryptoHelper")
-```
+Notes:
+- `class_name` is optional but strongly recommended for obfuscated apps.
+- If method overloads exist, provide `method_signature` as well.
 
-**Warning:** Affects multiple files. Use carefully.
+### `rename_field(class_name: str, field_name: str, new_name: str)`
+Renames field in a specific class.
 
----
+### `rename_package(old_package_name: str, new_package_name: str)`
+Renames package.
 
-### `rename_method(class_name: str, method_name: str, new_name: str)`
-
-Renames method and updates references.
-
----
-
-### `rename_package(old_pkg: str, new_pkg: str)`
-
-Renames an entire package and updates declarations/imports.
-
----
-
-### `rename_variable(class_name: str, method_name: str, old_var: str, new_var: str)`
-
-Renames a local variable inside a specific method.
+### `rename_variable(class_name: str, method_name: str, variable_name: str, new_name: str, reg: str = None, ssa: str = None)`
+Renames local variable with optional `reg` and `ssa` disambiguation.
 
 ---
 
 ## Debugging
 
 ### `debug_get_stack_frames()`
+Returns stack frames when debugger is active and suspended.
 
-Gets current call stack.
+### `debug_get_threads()`
+Returns debugged-process threads.
 
-**Requirements:**
-- Debugger active
-- Process suspended
-
-**Returns:**
-- List of stack frames (class, method, line)
+### `debug_get_variables()`
+Returns locals/fields from current debug context.
 
 ---
 
-### `debug_get_variables()`
+## Tool Count
 
-Gets local variables and fields.
-
-**Returns:**
-- Locals (name, type, value)
-- Fields (name, type, value)
-
-**Security Note:** Values may contain sensitive data (passwords, keys).
+Current MCP tool count exposed by `jadx_mcp_server.py`: **32**.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,136 +1,74 @@
 # System Architecture
 
-Deep dive into JADX-AI-MCP technical design.
+## Overview
 
-## High-Level Design
+JADX-AI-MCP uses a two-hop design:
 
-The system follows a **3-Tier Architecture**:
-
-1.  **Presentation Tier**: LLM Client (Claude, Cherry Studio)
-2.  **Application Tier**: MCP Server (Python)
-3.  **Data Tier**: JADX Plugin (Java) + JADX Core
+1. MCP client -> Python MCP server
+2. Python MCP server -> Java plugin HTTP API inside JADX-GUI
 
 ```mermaid
-block-beta
-  columns 3
-  LLM_Client(("LLM Client"))
-  block:MCP
-    MCPServer["MCP Server (Python)"]
-    FastMCP["FastMCP Lib"]
-  end
-  block:Plugin
-    Javalin["Javalin Server"]
-    JADXAPI["JADX API"]
-    GUI["JADX GUI"]
-  end
-
-  LLM_Client --> MCPServer
-  MCPServer --> Javalin
-  Javalin --> JADXAPI
-  JADXAPI --> GUI
+graph LR
+    A[LLM MCP Client] --> B[jadx-mcp-server.py]
+    B --> C[JADX AI MCP Plugin HTTP routes]
+    C --> D[JADX Wrapper + Decompiler + Resources]
 ```
 
----
+## Runtime Layers
 
-## Threading Model
+- **Client layer**: Claude/Codex/other MCP clients
+- **MCP layer**: FastMCP tool registration (`jadx_mcp_server.py`)
+- **Plugin layer**: Javalin routes under `com.zin.jadxaimcp.server.routes`
+- **Decompiler layer**: JADX core + GUI state
 
-### Python Server (AsyncIO)
-- **Single-threaded Event Loop**: Uses `asyncio` for non-blocking I/O
-- **HTTP Client**: `httpx.AsyncClient` handles concurrent requests
-- **Concurrency**: Can handle multiple MCP tool calls simultaneously
+## Transport Modes
 
-### Java Plugin (Multi-threaded)
-- **HTTP Server**: Jetty (via Javalin) uses a thread pool (default: 200 threads)
-- **Request Handling**: Each request runs on a worker thread
-- **UI Interaction**: **CRITICAL** - All JADX API calls accessing UI/Data must run on **Event Dispatch Thread (EDT)**
+- **Stdio mode (default)**: best for local MCP clients
+  - stdout reserved for MCP frames
+  - logs/banners/health output to stderr
+- **HTTP mode (`--http`)**: optional streamable HTTP server
 
-**EDT Pattern:**
-```java
-// Wrong: Direct access from worker thread
-String code = javaClass.getCode(); // ConcurrentModificationException
+## Search and Progress
 
-// Correct: Wrap in invokeLater
-SwingUtilities.invokeLater(() -> {
-    String code = javaClass.getCode(); // Safe
-});
+- Long-running search tools poll `/search-progress`
+- Python search tooling reports progress through MCP context when supported
+- Java `SearchProgressTracker` tracks states like running/completed/failed
+
+## Caching
+
+- Java plugin includes a decompilation cache (`DecompilationCache`)
+- Exposed tools:
+  - `get_cache_stats()`
+  - `clear_cache()`
+
+## Security Model
+
+- Default bind for MCP server and plugin communication is localhost.
+- Remote bind (`--host` not localhost) is unauthenticated plain HTTP.
+- Python HTTP calls use `trust_env=False` to reduce proxy-side interference.
+
+## Pagination
+
+Many endpoints support `offset` and `count`/`limit`.  
+Python side normalizes paginated responses into:
+
+```json
+{
+  "type": "paginated-list",
+  "items": [],
+  "pagination": {
+    "total": 0,
+    "offset": 0,
+    "limit": 0,
+    "count": 0,
+    "has_more": false
+  }
+}
 ```
 
----
+## Source of Truth
 
-## State Management
-
-### Plugin State (Persistent)
-- **Port Configuration**: Stored in `Java Preferences` node `com.zin.jadxaimcp`
-- **Session State**: JADX project state (loaded APK, decompilation cache)
-
-### Server State (Transient)
-- **Configuration**: Loaded from CLI args at startup
-- **Connections**: No persistent connections (HTTP is stateless)
-
----
-
-## 🔒 Security Model
-
-### Network Security
-- **Localhost Binding**: Plugin binds ONLY to `127.0.0.1`. Remote access blocked.
-- **No Auth**: Relies on OS-level user isolation.
-
-### Input Validation
-- **Path Traversal**: Resource paths validated against APK root.
-- **SQL Injection**: Not applicable (no SQL database).
-- **Code Injection**: Refactoring inputs validated for Java naming rules.
-
-### Transport Security
-- **Proxy Isolation**: Python `httpx` client uses `trust_env=False` to prevent OS-level HTTP/HTTPS proxies from intercepting `127.0.0.1` traffic or routing internal API calls externally.
-- **Stdio Integrity**: When running as an MCP stdio server, all internal logging, health checks, and application banners write to `stderr`. The `stdout` stream is strictly reserved for JSON-RPC communication to prevent protocol corruption.
-
----
-
-## Performance Optimization
-
-### Pagination Strategy
-Large APKs can have 10,000+ classes. Returning all at once causes:
-1.  **JSON Serialization Overhead**: 10MB+ responses
-2.  **Network Latency**: Slow transfer
-3.  **Client Timeout**: LLM clients timeout after 60s
-
-**Solution**:
-- All list endpoints support `offset` and `count`
-- Default page size: 100 items
-- Maximum page size: 10,000 items
-
-### Caching
-- **JADX Core**: Caches decompiled source automatically
-- **Plugin**: Does NOT cache responses (to support real-time refactoring)
-
----
-
-## Protocol Specifications
-
-### MCP Protocol (JSON-RPC 2.0)
-- **Tools**: Exposed as MCP tools
-- **Resources**: Not currently used (everything is a tool)
-- **Prompts**: Not currently used
-
-### HTTP Protocol (Internal)
-- **Method**: GET (mostly)
-- **Format**: JSON
-- **Status Codes**:
-    - `200 OK`: Success
-    - `400 Bad Request`: Invalid params
-    - `404 Not Found`: Class/Method missing
-    - `500 Server Error`: Internal failure
-
----
-
-## Tech Stack
-
-| Component | Technology | Version | License |
-|-----------|------------|---------|---------|
-| **Plugin** | Java | 11+ | Apache 2.0 |
-| **Server** | Python | 3.10+ | Apache 2.0 |
-| **HTTP Server** | Javalin | 6.x | Apache 2.0 |
-| **JSON Lib** | Jackson | 2.15+ | Apache 2.0 |
-| **MCP Lib** | FastMCP | Latest | MIT |
-| **Build** | Gradle | 7.x | Apache 2.0 |
-| **Pkg Mgr** | UV | Latest | Apache 2.0 |
+For tool signatures and defaults, use:
+- `jadx-mcp-server/jadx_mcp_server.py`
+- Python tool modules in `jadx-mcp-server/src/server/tools/`
+- Java route handlers in `jadx-ai/src/main/java/com/zin/jadxaimcp/server/routes/`

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,3 +2,10 @@
 
 Starting from v6.0.0 all notable changes to JADX-AI-MCP will be documented here.
 
+## 2026-07 Documentation Sync
+
+- Updated ReadTheDocs pages to match current MCP tool signatures and route behavior.
+- Corrected refactor/search signature docs (`rename_method`, `search_classes_by_keyword`).
+- Reworked API, installation, architecture, examples, Python and Java references.
+- Clarified Python requirement differences between script mode and packaged install mode.
+

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,598 +1,102 @@
 # Examples
 
-Real-world examples demonstrating JADX-AI-MCP capabilities.
+These examples use current tool signatures and response behavior.
 
-## Table of Contents
-
-- [Security Analysis](#security-analysis)
-- [Reverse Engineering](#reverse-engineering)
-- [Debugging](#debugging)
-- [Code Refactoring](#code-refactoring)
-- [Malware Analysis](#malware-analysis)
-
----
-
-## Security Analysis
-
-### Example 1: Comprehensive Security Audit
-
-**Goal:** Perform a complete security assessment of an Android APK.
-
-**Prompt:**
-```
-Perform a comprehensive security audit:
-
-1. Get the AndroidManifest and identify dangerous permissions
-2. Get main application classes
-3. Search for hardcoded credentials
-4. Check for insecure crypto usage
-5. Identify WebView security issues
-6. Generate a detailed report
-```
-
-**Expected Workflow:**
+## 1) Entry-point mapping
 
 ```python
-# Step 1: Manifest analysis
-manifest = await get_android_manifest()
-permissions = manifest['permissions']
-
-dangerous_perms = [p for p in permissions if 'DANGEROUS' in p]
-# Found: CAMERA, READ_CONTACTS, ACCESS_FINE_LOCATION
-
-# Step 2: Get app classes
-classes = await get_main_application_classes_names()
-# 45 classes in com.example.app package
-
-# Step 3: Search for credentials
-creds_search = await search_classes_by_keyword("password")
-# Found 8 classes with password handling
-
-# Step 4: Crypto analysis
-crypto_search = await search_method_by_name("encrypt")
-# Found 3 encryption methods
-
-for result in crypto_search['results']:
-    source = await get_class_source(result['className'])
-    # Analyze crypto implementation
-
-# Step 5: WebView analysis
-webview_search = await search_classes_by_keyword("WebView")
-# Found 2 WebView implementations
-
-for webview_class in webview_search['results']:
-    source = await get_class_source(webview_class['className'])
-    # Check for setJavaScriptEnabled, SSL validation, etc.
+pkg_tree = await get_package_tree()
+main = await get_main_activity_class()
+app_classes = await get_main_application_classes_names()
 ```
 
-**AI Response:**
-```
-🔴 CRITICAL FINDINGS:
-1. Hardcoded API key in Config.class (line 45)
-2. DES encryption used instead of AES (CryptoHelper.java)
-3. WebView allows JavaScript without proper validation
+Then ask the LLM to rank likely auth/network/storage classes.
 
-🟡 WARNINGS:
-1. Over-privileged: CAMERA permission not used
-2. Cleartext HTTP traffic allowed
-3. SSL certificate validation disabled in NetworkManager
-
-📊 SUMMARY:
-- Critical: 3
-- High: 5
-- Medium: 8
-- Low: 12
-```
-
----
-
-### Example 2: Authentication Flow Analysis
-
-**Goal:** Understand and assess the security of the login mechanism.
-
-**Prompt:**
-```
-Analyze the authentication system:
-
-1. Get the main activity and find login entry point
-2. Trace the login method implementation
-3. Identify credential storage mechanism
-4. Check for password encryption
-5. Assess overall security
-```
-
-**Workflow:**
+## 2) Keyword search with scopes
 
 ```python
-# Find login activity
-main_activity = await get_main_activity_class()
-# com.example.app.SplashActivity
-
-# Search for login methods
-login_methods = await search_method_by_name("login")
-# Found: LoginActivity.performLogin()
-
-# Get login class source
-login_class = await get_class_source("com.example.app.LoginActivity")
-
-# Analyze password handling
-password_refs = await get_xrefs_to_field(
-    "com.example.app.LoginActivity", 
-    "password"
+crypto = await search_classes_by_keyword(
+    search_term="cipher",
+    search_in="method,code",
+    count=50,
 )
-
-# Check credential storage
-prefs_search = await search_classes_by_keyword("SharedPreferences")
 ```
-
-**Finding:**
-```
-⚠️ SECURITY ISSUE:
-The app stores username and password in SharedPreferences 
-without encryption.
-
-Location: LoginActivity.java, line 78
-Code: prefs.edit().putString("password", plainPassword).apply();
-
-Recommendation: Use Android Keystore or encrypt credentials
-```
-
----
-
-## Reverse Engineering
-
-### Example 3: Deobfuscation Workflow
-
-**Goal:** Systematically deobfuscate an obfuscated APK.
-
-**Prompt:**
-```
-Help me deobfuscate this app:
-
-1. Identify obfuscation patterns
-2. Locate main functionality
-3. Rename classes systematically
-4. Document findings
-```
-
-**Workflow:**
 
 ```python
-# Get all classes to identify patterns
-all_classes = await get_all_classes(offset=0, count=100)
-# Pattern identified: single-letter package names (a.b.c, d.e.f)
-
-# Get main app classes (usually less obfuscated)
-main_classes = await get_main_application_classes_names()
-# com.example.secure
-
-# Get main activity for context
-main_activity = await get_main_activity_class()
-# com.example.secure.a
-
-# Analyze main activity
-activity_source = await get_class_source("com.example.secure.a")
-# Contains: onCreate, initializeApp, loadConfig
-
-# Rename based on functionality
-await rename_class("com.example.secure.a", "MainActivity")
-await rename_method("a()", "initializeApp")
-await rename_method("b()", "loadConfig")
-
-# Find and rename helper classes
-xrefs = await get_xrefs_to_class("com.example.secure.b")
-# Referenced in MainActivity.initializeApp()
-# Appears to handle network requests
-
-await rename_class("com.example.secure.b", "NetworkManager")
-
-# Continue pattern for crypto classes
-crypto_search = await search_method_by_name("cipher")
-# Found in com.example.secure.c
-
-await rename_class("com.example.secure.c", "CryptoHelper")
+comments = await search_classes_by_keyword(
+    search_term="todo",
+    search_in="comment",
+    count=20,
+)
 ```
 
-**Result:**
-```
-✅ DEOBFUSCATION PROGRESS:
-
-Original → Renamed:
-com.example.secure.a → MainActivity
-com.example.secure.b → NetworkManager  
-com.example.secure.c → CryptoHelper
-com.example.secure.d → DatabaseHelper
-com.example.secure.e → AuthManager
-
-Methods renamed: 47
-Fields renamed: 23
-```
-
----
-
-### Example 4: Native Library Analysis
-
-**Goal:** Identify and analyze native (JNI) methods.
-
-**Prompt:**
-```
-Find and analyze native methods:
-
-1. Search for native method declarations
-2. Locate library loading code
-3. Identify JNI function mappings
-4. Get smali for detailed analysis
-```
-
-**Workflow:**
+## 3) Method lookup in known class
 
 ```python
-# Search for native keyword
-native_search = await search_classes_by_keyword("native ")
-
-# Typical finding: NativeLib class
-native_class = await get_class_source("com.example.NativeLib")
-
-# Get methods
-methods = await get_methods_of_class("com.example.NativeLib")
-# Found: native String decryptString(byte[])
-#        native void initialize()
-
-# Get smali for low-level analysis
-smali = await get_smali_of_class("com.example.NativeLib")
-
-# Find library loading
-loadlib_search = await search_classes_by_keyword("System.loadLibrary")
-# Found in NativeLib.<clinit>()
-# Loads: libnative-crypto.so
+method = await get_method_by_name(
+    class_name="com.example.auth.AuthManager",
+    method_name="login",
+    method_signature="(Ljava/lang/String;Ljava/lang/String;)Z",
+)
 ```
 
-**Finding:**
-```
-📦 NATIVE LIBRARY ANALYSIS:
-
-Library: libnative-crypto.so
-
-JNI Methods:
-1. Java_com_example_NativeLib_decryptString
-   - Implements custom crypto
-   - Takes encrypted byte array
-   - Returns decrypted String
-
-2. Java_com_example_NativeLib_initialize  
-   - Performs anti-debug checks
-   - Validates app signature
-   - Initializes crypto keys
-
-Next steps: Analyze .so file with Ghidra/IDA
-```
-
----
-
-## Debugging
-
-### Example 5: Runtime Analysis
-
-**Goal:** Understand runtime behavior during execution.
-
-**Prompt:**
-```
-I've set a breakpoint at LoginActivity.performLogin(). Help me analyze:
-
-1. Get current stack trace
-2. Inspect variables
-3. Check thread state
-4. Understand execution flow
-```
-
-**Workflow:**
+## 4) Xref tracing
 
 ```python
-# Breakpoint hit at LoginActivity.performLogin()
+refs = await get_xrefs_to_method(
+    class_name="com.example.auth.AuthManager",
+    method_name="login",
+    count=100,
+)
+```
 
-# Get stack frames
+`refs` is paginated with `items` containing `class` and `method`.
+
+## 5) Resource analysis
+
+```python
+manifest = await get_android_manifest()
+exported_activities = await get_manifest_component("activity", only_exported=True)
+strings = await get_strings(offset=0, count=200)
+```
+
+## 6) Refactor flow
+
+```python
+await rename_class("a.b.c", "CryptoHelper")
+await rename_field("com.example.Config", "a", "apiBaseUrl")
+await rename_variable("com.example.Auth", "login", "v0", "username")
+```
+
+Method rename (current signature):
+
+```python
+await rename_method("a", "initialize", class_name="com.example.MainActivity")
+# Better disambiguation if overloaded:
+await rename_method(
+    "a",
+    "initialize",
+    class_name="com.example.MainActivity",
+    method_signature="(Landroid/content/Context;)V",
+)
+```
+
+## 7) Debug snapshot
+
+```python
 stack = await debug_get_stack_frames()
-```
-
-**Output:**
-```json
-{
-  "stackFrames": [
-    {
-      "index": 0,
-      "className": "com.example.LoginActivity",
-      "methodName": "performLogin",
-      "lineNumber": 145
-    },
-    {
-      "index": 1,
-      "className": "com.example.LoginActivity", 
-      "methodName": "onClick",
-      "lineNumber": 98
-    },
-    {
-      "index": 2,
-      "className": "android.view.View",
-      "methodName": "performClick",
-      "lineNumber": 7000
-    }
-  ]
-}
-```
-
-```python
-# Get local variables
+threads = await debug_get_threads()
 variables = await debug_get_variables()
 ```
 
-**Output:**
-```json
-{
-  "locals": [
-    {
-      "name": "username",
-      "type": "String",
-      "value": "admin"
-    },
-    {
-      "name": "password",
-      "type": "String",
-      "value": "password123"
-    },
-    {
-      "name": "rememberMe",
-      "type": "boolean",
-      "value": "true"
-    }
-  ],
-  "fields": [
-    {
-      "name": "mAuthManager",
-      "type": "AuthManager",
-      "value": "com.example.AuthManager@7f8a9b"
-    }
-  ]
-}
-```
+Use these together for runtime flow analysis while paused.
+
+## 8) Cache maintenance
 
 ```python
-# Check threads
-threads = await debug_get_threads()
+stats_before = await get_cache_stats()
+cleared = await clear_cache()
+stats_after = await get_cache_stats()
 ```
 
-**Analysis:**
-```
-🔍 RUNTIME ANALYSIS:
-
-Execution Flow:
-User clicked login button → onClick() → performLogin()
-
-Current State:
-- Username: "admin" (plain text in memory)
-- Password: "password123" (plain text in memory)  
-- RememberMe: true
-
-⚠️ SECURITY ISSUE:
-Credentials stored as plain Strings in memory during auth process.
-Consider using char[] and clearing after use.
-
-Thread State:
-- Main thread: SUSPENDED (at breakpoint)
-- Background threads: 3 active (AsyncTask, NetworkThread)
-```
-
----
-
-## Code Refactoring
-
-### Example 6: Systematic Package Refactoring
-
-**Goal:** Refactor obfuscated packages to meaningful names.
-
-**Prompt:**
-```
-Refactor package structure:
-
-1. Identify current package structure
-2. Determine purpose of each package
-3. Rename to descriptive names
-4. Verify all references updated
-```
-
-**Workflow:**
-
-```python
-# Get current structure
-classes = await get_all_classes()
-
-# Group by package
-packages = {}
-for cls in classes['items']:
-    pkg = '.'.join(cls.split('.')[:-1])
-    if pkg not in packages:
-        packages[pkg] = []
-    packages[pkg].append(cls)
-
-# Analysis shows:
-# a.b.c - networking code (15 classes)
-# a.b.d - crypto code (8 classes)
-# a.b.e - database code (12 classes)
-
-# Rename packages
-await rename_package("a.b.c", "com.example.network")
-# ✅ Renamed 15 classes
-
-await rename_package("a.b.d", "com.example.crypto")
-# ✅ Renamed 8 classes
-
-await rename_package("a.b.e", "com.example.database")
-# ✅ Renamed 12 classes
-
-# Verify
-updated_classes = await get_all_classes()
-```
-
-**Result:**
-```
-✅ REFACTORING COMPLETE
-
-Before:
-├── a.b.c (15 classes)
-├── a.b.d (8 classes)
-└── a.b.e (12 classes)
-
-After:
-├── com.example.network (15 classes)
-├── com.example.crypto (8 classes)
-└── com.example.database (12 classes)
-
-Total updates: 35 classes, 487 references
-```
-
----
-
-## Malware Analysis
-
-### Example 7: Behavioral Analysis
-
-**Goal:** Identify potentially malicious behaviors.
-
-**Prompt:**
-```
-Scan for suspicious behaviors:
-
-1. Check for dynamic code loading
-2. Find data exfiltration code
-3. Identify anti-analysis techniques
-4. Locate obfuscated strings
-5. Check for root detection
-```
-
-**Workflow:**
-
-```python
-# Check 1: Dynamic code loading
-dex_search = await search_classes_by_keyword("DexClassLoader")
-# Found: com.malware.Loader
-
-loader_class = await get_class_source("com.malware.Loader")
-# Downloads and executes remote DEX file
-
-# Check 2: Data exfiltration
-http_search = await search_classes_by_keyword("HttpURLConnection")
-# Found: com.malware.Uploader
-
-uploader_xrefs = await get_xrefs_to_class("com.malware.Uploader")
-# Called from multiple locations, sends device data
-
-# Check 3: Anti-analysis
-debug_search = await search_classes_by_keyword("isDebuggerConnected")
-# Found: com.malware.AntiDebug
-
-anti_debug = await get_class_source("com.malware.AntiDebug")
-# Checks for debugger, emulator, and root
-
-# Check 4: String obfuscation
-string_methods = await search_method_by_name("decryptString")
-# Found: com.malware.StringObf.decryptString()
-
-# Get smali for analysis
-smali = await get_smali_of_class("com.malware.StringObf")
-
-# Check 5: Root detection
-root_search = await search_classes_by_keyword("su binary")
-# Found: com.malware.RootCheck
-```
-
-**Report:**
-```
-🔴 MALWARE DETECTED
-
-Malicious Behaviors:
-1. ✓ Dynamic DEX loading from remote server
-2. ✓ Exfiltrates IMEI, contacts, SMS
-3. ✓ Anti-debugging/anti-emulator checks
-4. ✓ String obfuscation (AES encrypted strings)
-5. ✓ Root detection with privilege escalation attempt
-
-C2 Servers:
-- http://malicious-c2.com/gate.php
-- http://192.168.1.100:8080/upload
-
-Risk Level: CRITICAL
-Recommendation: Quarantine and report to authorities
-```
-
----
-
-### Example 8: Permission Analysis
-
-**Goal:** Identify permission abuse and privacy risks.
-
-**Prompt:**
-```
-Analyze permissions and privacy:
-
-1. List all declared permissions
-2. For each permission, find usage in code
-3. Identify overprivileged permissions
-4. Check for privacy violations
-```
-
-**Workflow:**
-```python
-# Get manifest
-manifest = await get_android_manifest()
-permissions = manifest['permissions']
-
-analysis = {}
-for perm in permissions:
-    # Find where permission is used
-    perm_name = perm.split('.')[-1]  # e.g., CAMERA
-
-    # Search for related code
-    usage = await search_classes_by_keyword(perm_name.lower())
-
-    analysis[perm] = {
-        'declared': True,
-        'used': len(usage['results']) > 0,
-        'usage_count': len(usage['results']),
-        'locations': usage['results']
-    }
-
-# Generate report
-for perm, data in analysis.items():
-    if data['declared'] and not data['used']:
-        print(f"⚠️ Unused permission: {perm}")
-    elif data['used']:
-        print(f"✓ {perm}: Used in {data['usage_count']} locations")
-```
-
-**Output:**
-```
-📊 PERMISSION ANALYSIS
-
-Declared Permissions: 12
-
-✓ INTERNET: Used in 8 locations
-  - NetworkManager.makeRequest()
-  - Uploader.sendData()
-  - AdSDK.loadAds()
-
-⚠️ CAMERA: Declared but NEVER used
-⚠️ READ_CONTACTS: Declared but NEVER used
-
-✓ ACCESS_FINE_LOCATION: Used in 2 locations
-  - LocationTracker.getLocation()
-  - AnalyticsSDK.trackUser()
-
-🔴 PRIVACY CONCERNS:
-1. Location accessed for analytics (not disclosed)
-2. CAMERA/CONTACTS permissions unused (should remove)
-3. Ad SDK has INTERNET access (data sharing possible)
-
-Recommendation:
-- Remove unused CAMERA and READ_CONTACTS permissions
-- Disclose location usage in privacy policy
-- Review Ad SDK data collection practices
-```
+Useful after switching APKs or after bulk decompilation requests.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,204 +1,80 @@
 # JADX-AI-MCP Documentation
 
-Welcome to the comprehensive documentation for **JADX-AI-MCP**, an AI-powered Android reverse engineering toolkit that bridges JADX decompiler with Large Language Models through the Model Context Protocol.
+JADX-AI-MCP combines a JADX GUI plugin with a Python MCP server so LLM clients can analyze Android APKs through live JADX context.
 
-## What is JADX-AI-MCP?
+## Components
 
-JADX-AI-MCP is a sophisticated reverse engineering solution consisting of two tightly integrated components:
+1. **JADX-AI-MCP Plugin (Java)**  
+   Embedded HTTP server inside JADX-GUI.
+2. **JADX-MCP-Server (Python)**  
+   FastMCP server exposing JADX operations as MCP tools.
 
-1. **JADX-AI-MCP Plugin (Java)** - A JADX-GUI plugin that exposes the decompiler's functionality through a local HTTP API
-2. **JADX-MCP-Server (Python)** - An MCP server that translates HTTP endpoints into MCP tools consumable by AI assistants
-
-Together, these components enable real-time, AI-assisted Android application analysis, vulnerability detection, and code understanding.
-
-## Key Features
-
-### Advanced Analysis Capabilities
-- **Real-time Code Review**: AI analyzes decompiled code as you navigate
-- **Cross-Reference Analysis**: Track method/class/field usage across entire codebases
-- **Resource Extraction**: Access manifests, strings, layouts, and resources
-- **Smali Analysis**: Low-level bytecode inspection for deep analysis
-
-### Security & Reverse Engineering
-- **Vulnerability Detection**: Automated SAST (Static Application Security Testing)
-- **Malware Analysis**: Behavioral pattern detection and C2 identification
-- **Obfuscation Analysis**: Systematic deobfuscation workflows
-- **Permission Auditing**: Identify overprivileged and unused permissions
-
-### Development Assistance
-- **Intelligent Refactoring**: AI-assisted renaming of obfuscated classes, methods, fields, variables, and packages
-- **Debug Integration**: Runtime variable inspection and stack trace analysis
-- **Pagination Support**: Efficient handling of large APKs (10,000+ classes)
-- **Multi-Client Support**: Works with Claude, Cherry Studio, LM Studio, Codex
-- **Remote Access**: Docker, WSL, and remote VM support via `--host` binding
-
-## Architecture Overview
+## Architecture
 
 ```mermaid
-graph TB
-    subgraph "User Layer"
-        A[User] -->|Natural Language| B[LLM Client]
-    end
+sequenceDiagram
+    participant LLM as LLM Client
+    participant MCP as jadx-mcp-server (Python)
+    participant Plugin as JADX AI MCP Plugin (Java)
+    participant GUI as JADX GUI/Core
 
-    subgraph "MCP Layer"
-        B -->|MCP Protocol| C[MCP Server Python]
-        C -->|Tool Invocation| D[FastMCP Framework]
-    end
-
-    subgraph "Integration Layer"
-        D -->|HTTP Request| E[JADX Plugin Server]
-        E -->|Javalin Routes| F[Route Handlers]
-    end
-
-    subgraph "Analysis Layer"
-        F -->|JADX API| G[JADX Wrapper]
-        G -->|Query| H[Decompiled Code]
-        G -->|Query| I[Resources]
-        G -->|Query| J[Debug Info]
-    end
-
-    H -->|Response| F
-    I -->|Response| F
-    J -->|Response| F
+    LLM->>MCP: MCP tool call
+    MCP->>Plugin: HTTP request
+    Plugin->>GUI: Query/Action
+    GUI-->>Plugin: Data/Result
+    Plugin-->>MCP: HTTP response
+    MCP-->>LLM: MCP tool result
 ```
 
-### Network Architecture
+## Runtime Requirements
 
-There are **two separate connections** in the system:
+| Component | Requirement |
+|---|---|
+| Java | 11+ |
+| JADX | 1.5.1+ |
+| Python | 3.10+ |
+| UV | Latest recommended |
 
-```
-┌─────────────┐    --host / --port     ┌──────────────────┐   --jadx-host / --jadx-port   ┌──────────────────┐
-│  LLM Client │ ◄──────────────────►   │  jadx-mcp-server │ ──────────────────────────►   │  JADX-GUI Plugin │
-│  (Claude,   │   Where the MCP server │                  │   Where the MCP server looks  │  (jadx-ai-mcp)   │
-│   Codex..)  │   LISTENS for clients  │                  │   for the JADX plugin         │                  │
-└─────────────┘                        └──────────────────┘                               └──────────────────┘
-```
+## Tooling Overview
+
+Current tool categories:
+- Class/navigation tools
+- Search tools
+- Resource tools
+- Xref tools
+- Refactor tools
+- Debug tools
+- Cache/package helpers
+
+See complete signatures in [API Reference](api-reference.md).
 
 ## Quick Start
 
-### Prerequisites
-
-| Component | Version Required | Purpose |
-|-----------|-----------------|---------|
-| Java | 11+ | JADX Plugin runtime |
-| Python | 3.10+ | MCP Server runtime |
-| JADX | 1.5.1+ (r2333+) | Decompilation engine |
-| UV | Latest | Python package manager |
-
-### Installation (5 minutes)
-
 ```bash
-# Step 1: Install JADX Plugin
+# Install plugin
 jadx plugins --install "github:zinja-coder:jadx-ai-mcp"
 
-# Step 2: Download MCP Server
-wget https://github.com/zinja-coder/jadx-ai-mcp/releases/latest/download/jadx-mcp-server.zip
-unzip jadx-mcp-server.zip
-
-# Step 3: Install UV
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Step 4: Run MCP Server
+# Run MCP server (stdio mode)
 cd jadx-mcp-server
 uv run jadx_mcp_server.py
-
-# Step 5: Configure Claude Desktop
-# Edit: ~/.config/Claude/claude_desktop_config.json
 ```
 
-See [Installation Guide](installation.md) for detailed instructions.
+Then configure your MCP client to launch the same command.
 
-## 📚 Documentation Structure
+## Security Notes
 
-### For Users
-- **[Installation Guide](installation.md)** - Complete setup for all platforms
-- **[User Guide](user-guide.md)** - Workflows, prompts, and best practices
-- **[Examples](examples.md)** - Real-world analysis scenarios
+- Default bind is localhost.
+- If using `--host 0.0.0.0`, traffic is unauthenticated plain HTTP.
+- Stdio mode keeps stdout reserved for MCP JSON-RPC (logs go to stderr).
 
-### For Developers
-- **[API Reference](api-reference.md)** - Complete tool documentation with examples
-- **[Architecture](architecture.md)** - System design and component interaction
-- **[Python Module Reference](python-api.md)** - Server-side code documentation
-- **[Java Plugin Reference](java-api.md)** - Plugin internals and extension points
+## Next
 
-### Support
-- **[Troubleshooting](troubleshooting.md)** - Common issues and solutions
-- **[Contributing](contributing.md)** - Development guidelines
-
-## 🔧 Tool Categories
-
-### Class Analysis Tools (10 tools)
-Tools for analyzing decompiled Java classes, methods, and fields.
-
-→ [View Class Tools](api-reference.md#class-analysis)
-
-### Search Tools (3 tools)
-Full-text search across classes, methods, and code with advanced scope filtering.
-
-→ [View Search Tools](api-reference.md#search-capabilities)
-
-### Resource Tools (5 tools)
-Access to AndroidManifest components, strings, layouts, and resources.
-
-→ [View Resource Tools](api-reference.md#resource-analysis)
-
-### Cross-Reference Tools (3 tools)
-Track usage of classes, methods, and fields across codebase.
-
-→ [View Xref Tools](api-reference.md#cross-reference-analysis)
-
-### Refactoring Tools (5 tools)
-Rename classes, methods, fields, variables, and packages.
-
-→ [View Refactor Tools](api-reference.md#refactoring)
-
-### Debug Tools (3 tools)
-Runtime analysis during JADX debugging sessions.
-
-→ [View Debug Tools](api-reference.md#debugging)
-
-## 🔐 Security & Privacy
-
-- **Secure Defaults**: Server binds to `127.0.0.1` only — remote access must be explicitly enabled
-- **No Authentication**: When binding to non-localhost with `--host 0.0.0.0`, traffic is unencrypted and unauthenticated — use only on trusted networks
-- **Proxy Isolation**: Internal HTTP requests use `trust_env=False` to prevent proxy interception
-- **No Data Collection**: No telemetry or usage tracking
-- **Stdio Safety**: Banner and health check output goes to stderr to prevent JSON-RPC stream pollution
-- **Open Source**: Fully auditable codebase
-
-!!! warning "Remote Binding"
-    When using `--host 0.0.0.0`, the MCP server is accessible to anyone on the network over plain HTTP. Use a firewall or SSH tunnel for remote access.
-
-## Supported Platforms
-
-| Platform | Plugin Support | Server Support | Status |
-|----------|---------------|----------------|--------|
-| Linux | ✅ Full | ✅ Full | Tested |
-| macOS | ✅ Full | ✅ Full | Tested |
-| Windows | ✅ Full | ✅ Full | Tested |
-
-## 🤝 Community & Support
-
-- **GitHub Issues**: [Report bugs](https://github.com/zinja-coder/jadx-ai-mcp/issues)
-- **GitHub Discussions**: [Ask questions](https://github.com/zinja-coder/jadx-ai-mcp/discussions)
-
-## 📄 License
-
-Apache License 2.0 - See [LICENSE](license.md)
-
-## Acknowledgments
-
-- **JADX Project**: [@skylot](https://github.com/skylot) - Amazing decompiler
-- **Anthropic**: Model Context Protocol development
-- **FastMCP**: [@jlowin](https://github.com/jlowin) - Python MCP framework
-
-## Next Steps
-
-1. **New Users**: Start with [Installation](installation.md)
-2. **Quick Demo**: See [Examples](examples.md)
-3. **API Exploration**: Browse [API Reference](api-reference.md)
-4. **Contributing**: Read [Contributing Guide](contributing.md)
+- [Installation](installation.md)
+- [User guide](user-guide.md)
+- [Examples](examples.md)
+- [API reference](api-reference.md)
 
 ---
 
-**Current Version**: 6.3.0 | **Last Updated**: March 2026
+**Plugin version in source (`pom.xml`)**: `6.4.0`  
+**Docs update**: July 2026

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,137 +1,45 @@
 # Installation Guide
 
-This guide covers the complete installation process for JADX-AI-MCP.
-
 ## Prerequisites
 
-### System Requirements
+- Java 11+
+- JADX 1.5.1+
+- UV installed
+- Python 3.10+
 
-- **Operating System**: Windows, macOS, or Linux
-- **Java**: Version 11 or higher
-- **Python**: Version 3.10 or higher
-- **JADX**: Version 1.5.1+ (r2333+)
+## 1) Install the JADX plugin
 
-### Check Prerequisites
-
-```bash
-# Check Java version
-java -version
-
-# Check Python version
-python --version
-
-# Check JADX version
-jadx --version
-```
-
-## Installation Methods
-
-### Method 1: One-Line Installation (Recommended)
-
-The easiest way to install the plugin:
+Recommended:
 
 ```bash
 jadx plugins --install "github:zinja-coder:jadx-ai-mcp"
 ```
 
-This command automatically downloads and installs the latest version of the plugin.
+Alternative: install the release JAR from JADX GUI plugin manager.
 
-### Method 2: Manual Installation via JADX-GUI
-
-1. Download the latest release from [GitHub Releases](https://github.com/zinja-coder/jadx-ai-mcp/releases)
-2. Download both:
-   - `jadx-ai-mcp-<version>.jar`
-   - `jadx-mcp-server-<version>.zip`
-
-3. Open JADX-GUI
-4. Navigate to: **Plugins → Install Plugin**
-5. Select the downloaded `.jar` file
-6. Restart JADX-GUI
-
-![Plugin Installation](assets/img_1231.png)
-
-### Method 3: Build from Source
+## 2) Prepare MCP server
 
 ```bash
-# Clone the repository
 git clone https://github.com/zinja-coder/jadx-ai-mcp.git
-cd jadx-ai-mcp
-
-# Build the plugin
-./gradlew build
-
-# The built JAR will be in build/libs/
-# Install it using Method 2 above
-```
-
-## MCP Server Setup
-
-### Step 1: Extract Server Files
-
-```bash
-# Download server package
-wget https://github.com/zinja-coder/jadx-ai-mcp/releases/latest/download/jadx-mcp-server.zip
-
-# Extract
-unzip jadx-mcp-server.zip
-cd jadx-mcp-server
-```
-
-### Step 2: Install UV Package Manager
-
-UV is a fast Python package manager used by this project:
-
-```bash
-# Linux/macOS
-curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Windows (PowerShell)
-powershell -c "irm https://astral.sh/uv/install.ps1 | iex"
-```
-
-### Step 3: Verify Installation
-
-```bash
-# Check UV installation
+cd jadx-ai-mcp/jadx-mcp-server
 uv --version
+```
 
-# Test server (should show usage info)
+## 3) Validate server startup
+
+```bash
 uv run jadx_mcp_server.py --help
 ```
 
-### Optional: Create Virtual Environment
+Run (stdio mode, recommended for desktop MCP clients):
 
 ```bash
-# Create venv (optional but recommended for troubleshooting)
-uv venv
-source .venv/bin/activate  # Linux/macOS
-# OR
-.venv\Scripts\activate  # Windows
-
-# Install dependencies manually
-uv pip install httpx fastmcp
+uv run jadx_mcp_server.py
 ```
 
-## LLM Client Configuration
+## 4) Configure MCP client
 
-### Claude Desktop
-
-#### Linux Configuration
-
-```bash
-# Edit config file
-nano ~/.config/Claude/claude_desktop_config.json
-```
-
-#### Windows Configuration
-
-Location: `%APPDATA%\Claude\claude_desktop_config.json`
-
-#### macOS Configuration
-
-Location: `~/Library/Application Support/Claude/claude_desktop_config.json`
-
-#### Configuration Content
+Use absolute paths.
 
 ```json
 {
@@ -140,7 +48,7 @@ Location: `~/Library/Application Support/Claude/claude_desktop_config.json`
       "command": "/path/to/uv",
       "args": [
         "--directory",
-        "/path/to/jadx-mcp-server/",
+        "/absolute/path/to/jadx-ai-mcp/jadx-mcp-server",
         "run",
         "jadx_mcp_server.py"
       ]
@@ -149,25 +57,15 @@ Location: `~/Library/Application Support/Claude/claude_desktop_config.json`
 }
 ```
 
-**Important**: Replace paths with absolute paths on your system.
-
-#### Find UV Path
+## Optional: install as a tool
 
 ```bash
-# Linux/macOS
-which uv
-
-# Windows
-where uv
+uv tool install git+https://github.com/zinja-coder/jadx-mcp-server
 ```
 
-### Alternative: Install as UV Tool
+Then:
 
-```bash
-# Install globally as a UV tool
-uv tool install git+https://github.com/zinja-coder/jadx-mcp-server
-
-# Then use simplified config
+```json
 {
   "mcpServers": {
     "jadx-mcp-server": {
@@ -177,167 +75,26 @@ uv tool install git+https://github.com/zinja-coder/jadx-mcp-server
 }
 ```
 
-### Cherry Studio Configuration
+Packaged install also supports Python 3.10+.
 
-1. Open Cherry Studio settings
-2. Navigate to MCP configuration
-3. Add new MCP server:
-   - **Type**: stdio
-   - **Command**: `uv`
-   - **Arguments**:
-     ```
-     --directory
-     /path/to/jadx-mcp-server
-     run
-     jadx_mcp_server.py
-     ```
-
-### LM Studio Configuration
-
-1. Open LM Studio
-2. Navigate to MCP settings
-3. Edit `mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "jadx-mcp-server": {
-      "command": "/path/to/uv",
-      "args": [
-        "--directory",
-        "/path/to/jadx-mcp-server",
-        "run",
-        "jadx_mcp_server.py"
-      ]
-    }
-  }
-}
-```
-
-## Remote & Custom Configuration
-
-### CLI Flags Reference
-
-There are **two separate connections** and each has its own host/port.
-
-```
-┌─────────────┐    --host / --port     ┌──────────────────┐   --jadx-host / --jadx-port   ┌──────────────────┐
-│  LLM Client │ ◄──────────────────►   │  jadx-mcp-server │ ──────────────────────────►   │  JADX-GUI Plugin │
-│  (Claude,   │   Where the MCP server │                  │   Where the MCP server looks  │  (jadx-ai-mcp)   │
-│   Codex..)  │   LISTENS for clients  │                  │   for the JADX plugin         │                  │
-└─────────────┘                        └──────────────────┘                               └──────────────────┘
-```
-
-| Flag | Default | Controls |
-|------|---------|----------|
-| `--http` | off | Use HTTP transport instead of stdio |
-| `--host` | `127.0.0.1` | **Where the MCP server listens** (bind address for LLM clients) |
-| `--port` | `8651` | **Which port the MCP server listens on** |
-| `--jadx-host` | `127.0.0.1` | **Where to find the JADX plugin** (the target JADX-GUI machine) |
-| `--jadx-port` | `8650` | **Which port the JADX plugin is on** |
-
-### HTTP Stream Mode (Optional)
-
-Run the server in HTTP mode for remote access from an LLM client:
+## HTTP mode (optional)
 
 ```bash
-# Default HTTP mode (localhost:8651)
 uv run jadx_mcp_server.py --http
-
-# Custom port
-uv run jadx_mcp_server.py --http --port 9999
 ```
 
-### Remote / Docker / WSL Access
+Useful flags:
+- `--host` / `--port`: where MCP server listens
+- `--jadx-host` / `--jadx-port`: where MCP server reaches JADX plugin
 
-To make the MCP server accessible from other machines (e.g., if you run the MCP server in Docker, or via WSL, and the LLM client is on the host Windows machine):
+## Security warning
 
-```bash
-# Bind to all interfaces
-uv run jadx_mcp_server.py --http --host 0.0.0.0
+Using `--host 0.0.0.0` exposes an unauthenticated HTTP service.  
+Use only on trusted networks and prefer firewall/SSH tunnel controls.
 
-# Bind to all interfaces on a custom port
-uv run jadx_mcp_server.py --http --host 0.0.0.0 --port 9999
-```
+## Verification Checklist
 
-!!! danger "Security Warning — Remote Binding"
-    When using `--host 0.0.0.0` (or any non-localhost address), the MCP server binds to **all network interfaces** over **plain HTTP with no authentication**.
-    - **Anyone on the network** can connect and invoke all MCP tools.
-    - There is **no TLS encryption** — traffic can be intercepted.
-    - An attacker can use the server to read decompiled code, modify it, and access debug info.
-    - **Mitigation:** Only bind to `0.0.0.0` on trusted, isolated networks (e.g., Docker bridge), use a firewall, or tunnel via SSH.
-
-### Remote JADX Plugin Configuration
-
-If the JADX AI MCP Plugin is running on a **different machine** (e.g., JADX on a remote VM, MCP server on your local host), use the `--jadx-host` option:
-
-```bash
-# Connect to JADX plugin on a remote host
-uv run jadx_mcp_server.py --jadx-host 192.168.1.100 --jadx-port 8650
-```
-
-### Custom Plugin Port Configuration
-
-If you change the JADX-GUI Plugin port:
-
-1. Open JADX-GUI with the plugin installed
-2. Navigate to: **Plugins → JADX-AI-MCP → Configure Port**
-3. Enter desired port (default: 8650)
-4. Click **Restart Server**
-
-![Port Configuration](assets/port-config.png)
-
-When using custom plugin port:
-
-```bash
-# Connect to plugin on custom port
-uv run jadx_mcp_server.py --jadx-port 8652
-```
-
-Update LLM client configuration appropriately:
-
-```json
-{
-  "mcpServers": {
-    "jadx-mcp-server": {
-      "command": "/path/to/uv",
-      "args": [
-        "--directory",
-        "/path/to/jadx-mcp-server/",
-        "run",
-        "jadx_mcp_server.py",
-        "--jadx-host",
-        "192.168.1.100",
-        "--jadx-port",
-        "8652"
-      ]
-    }
-  }
-}
-```
-
-## Verification
-
-### 1. Check Plugin Status
-
-1. Open JADX-GUI
-2. Load any APK file
-3. Check: **Plugins → JADX-AI-MCP → Server Status**
-4. Should show: "Server Running on port 8650"
-
-### 2. Check MCP Server Connection
-
-1. Open your LLM client (Claude/Cherry Studio/LM Studio)
-2. Look for hammer icon (🔨) or MCP tools indicator
-3. Click and verify "jadx-mcp-server" is listed
-4. Should show ~30 available tools
-
-### 3. Test Basic Functionality
-
-Run this prompt in your LLM client:
-
-```
-List all available JADX MCP tools
-```
-
-Expected response: List of 30+ tools including `fetch_current_class`, `get_android_manifest`, etc.
+1. Open JADX-GUI with an APK loaded.
+2. Confirm plugin server status in plugin menu.
+3. Start MCP client and verify `jadx-mcp-server` tools appear.
+4. Test with prompt: `List available JADX MCP tools`.

--- a/docs/java-api.md
+++ b/docs/java-api.md
@@ -1,248 +1,108 @@
-# Java Plugin API Reference
+# Java Plugin Reference
 
-Complete reference for the JADX-AI-MCP Java plugin codebase.
+This page reflects the current Java plugin structure and route handlers.
 
-## Core Plugin Architecture
+## Core Plugin Class
 
-The plugin is built on top of JADX's plugin system and exposes functionality via an embedded Javalin HTTP server.
+### `com.zin.jadxaimcp.JadxAIMCP`
 
-### Class: `JadxAIMCP`
+Key responsibilities:
 
-**Package**: `com.zin.jadxaimcp`
+- Implements `JadxPlugin`
+- Registers plugin metadata (`PLUGIN_ID = "jadx-ai-mcp"`)
+- Initializes menu integration
+- Starts plugin HTTP server with delayed startup logic
+- Persists plugin port with Java Preferences
 
-The main entry point implementing `JadxPlugin`.
+Notable defaults:
 
-#### Lifecycle Methods
+- Default plugin port: `8650`
 
-| Method | Description |
-|--------|-------------|
-| `init(JadxPluginContext context)` | Initializes plugin, UI components, and delayed server startup |
-| `getPluginInfo()` | Returns metadata (ID, name, description, homepage) |
-| `startDelayedInitialization()` | Waits for JADX to load APK content before starting server |
-| `startServer()` | Starts the embedded HTTP server on configured port |
+## HTTP Server
 
-#### State Management
+### `com.zin.jadxaimcp.server.PluginServer`
 
-- **Persistence**: Uses `Java Preferences API` to store port configuration
-- **Threading**: Uses `ScheduledExecutorService` for background tasks
-- **UI Integration**: Injects menu items into JADX-GUI via `PluginMenu`
+Creates embedded Javalin server and registers routes.
 
-**Example:**
-```java
-// Delayed initialization pattern
-private void startDelayedInitialization() {
-    scheduler.scheduleAtFixedRate(() -> {
-        if (isJadxFullyLoaded()) {
-            startServer();
-            scheduler.shutdown();
-        }
-    }, 2, 1, TimeUnit.SECONDS);
-}
-```
+Current route groups:
 
----
+- Health/general
+- Class/source/navigation
+- Search
+- Resource
+- Refactor
+- Xrefs
+- Debug
+- Cache/package helpers
 
-## HTTP Server & Routing
+## Route Controllers
 
-### Class: `PluginServer`
+Located in:
 
-**Package**: `com.zin.jadxaimcp`
+- `com.zin.jadxaimcp.server.routes.GeneralRoutes`
+- `ClassRoutes`
+- `MethodRoutes`
+- `ResourceRoutes`
+- `RefactoringRoutes`
+- `XrefsRoutes`
+- `DebugRoutes`
 
-Manages the embedded Jetty server via Javalin framework.
+### Important route behavior details
 
-#### Configuration
+- Several handlers return plain text via `ctx.result(...)`.
+- Others return JSON via `ctx.json(...)`.
+- Pagination is handled with `com.zin.jadxaimcp.utils.PaginationUtils`.
+- Search progress state comes from `SearchProgressTracker`.
 
-- **Host**: `127.0.0.1` (Localhost only for security)
-- **Port**: Configurable (default: 8650)
-- **JSON Mapper**: Uses Jackson for serialization
+## Refactor Route Notes
 
-#### Route Registration
+### `RefactoringRoutes.handleRenameMethod(...)`
 
-```java
-app.get("/class-source", ClassRoutes::getClassSource);
-app.get("/all-classes", ClassRoutes::getAllClasses);
-app.get("/search-method", SearchRoutes::searchMethod);
-// ... more routes
-```
+Current HTTP params:
 
----
+- optional `class_name`
+- `method_name`
+- `new_name`
+- optional `method_signature`
 
-## Route Handlers
+## Search Route Notes
 
-### Class: `ClassRoutes`
+### `ClassRoutes.handleSearchClassesByKeyword(...)`
 
-**Package**: `com.zin.jadxaimcp.routes`
+Current `search_in` values:
 
-Handles all class-related operations.
+- `class`
+- `method`
+- `field`
+- `code`
+- `comment`
 
-#### Methods
-
-| Endpoint | Method Handler | Description |
-|----------|----------------|-------------|
-| `/class-source` | `getClassSource` | Fetches decompiled source code |
-| `/all-classes` | `getAllClasses` | Returns paginated class list |
-| `/smali-of-class` | `getSmali` | Returns Smali bytecode |
-| `/fields-of-class` | `getFields` | Lists class fields |
-
-**Implementation Example:**
-```java
-public static void getClassSource(Context ctx) {
-    String className = ctx.queryParam("class_name");
-
-    // Access JADX API on EDT
-    SwingUtilities.invokeLater(() -> {
-        JavaClass cls = wrapper.searchJavaClassByFullName(className);
-        String source = cls.getCode();
-
-        Platform.runLater(() -> {
-            ctx.json(Map.of("source", source));
-        });
-    });
-}
-```
-
----
-
-### Class: `SearchRoutes`
-
-**Package**: `com.zin.jadxaimcp.routes`
-
-Handles search operations across the decompiled codebase.
-
-#### Methods
-
-| Endpoint | Method Handler | Description |
-|----------|----------------|-------------|
-| `/search-method` | `searchMethod` | Finds methods by name |
-| `/search-classes-by-keyword` | `searchClasses` | Full-text code search (supports scopes & packages) |
-
-**Implementation Note:**
-Full-text search uses JADX's incremental search index for performance.
-
----
-
-### Class: `XrefsRoutes`
-
-**Package**: `com.zin.jadxaimcp.routes`
-
-Handles cross-reference analysis.
-
-#### Methods
-
-| Endpoint | Method Handler | Description |
-|----------|----------------|-------------|
-| `/xrefs-to-class` | `getXrefsToClass` | Finds class usages |
-| `/xrefs-to-method` | `getXrefsToMethod` | Finds method calls |
-| `/xrefs-to-field` | `getXrefsToField` | Finds field accesses |
-
-**Key Feature:**
-Resolves method overrides and super calls automatically.
-
----
-
-### Class: `RefactoringRoutes`
-
-**Package**: `com.zin.jadxaimcp.routes`
-
-Handles code renaming operations.
-
-#### Methods
-
-| Endpoint | Method Handler | Description |
-|----------|----------------|-------------|
-| `/rename-class` | `renameClass` | Renames class & updates refs |
-| `/rename-method` | `renameMethod` | Renames method & updates calls |
-| `/rename-field` | `renameField` | Renames field & updates accesses |
-| `/rename-variable` | `renameVariable` | Renames local variables within a method |
-| `/rename-package` | `renamePackage` | Renames package & updates all classes |
-
-**Safety Check:**
-Validates new names against Java naming conventions before applying.
-
----
+Default search location: `code`.
 
 ## Utilities
 
-### Class: `PaginationUtils`
+### `com.zin.jadxaimcp.utils.DecompilationCache`
 
-**Package**: `com.zin.jadxaimcp.utils`
+Used by class/search paths and exposed through:
 
-Provides consistent pagination logic for large datasets.
+- `/cache-stats`
+- `/cache-clear`
 
-#### Methods
+### `com.zin.jadxaimcp.utils.PaginationUtils`
 
-| Method | Description |
-|--------|-------------|
-| `paginate(List<T> list, int offset, int limit)` | Returns sublist with metadata |
-| `validateParams(int offset, int limit)` | Ensures safe bounds |
+Shared pagination helper for class/xref/search-like endpoints.
 
-**Pagination Response Format:**
-```json
-{
-  "items": [...],
-  "pagination": {
-    "total": 1500,
-    "offset": 0,
-    "limit": 100,
-    "count": 100,
-    "has_more": true
-  }
-}
-```
+### `com.zin.jadxaimcp.utils.JadxAIMCPPluginError`
 
----
+Centralized HTTP error response helper used by route handlers.
 
-## Extension Guide
+## Practical Extension Path
 
-### How to Add a New Route
+To add a new capability:
 
-1. **Create Handler Method** in appropriate Route class:
-```java
-// routes/MyRoutes.java
-public static void myHandler(Context ctx) {
-    String param = ctx.queryParam("param");
-    // logic...
-    ctx.json(result);
-}
-```
+1. Add route handler in `server/routes/*`
+2. Register route in `PluginServer.registerRoutes()`
+3. Add Python wrapper in `jadx-mcp-server/src/server/tools/*`
+4. Register MCP tool in `jadx_mcp_server.py`
 
-2. **Register Route** in `PluginServer.java`:
-```java
-app.get("/my-endpoint", MyRoutes::myHandler);
-```
-
-3. **Add Python Tool** in `src/server/tools/`:
-```python
-async def my_tool(param: str):
-    return await get_from_jadx("my-endpoint", {"param": param})
-```
-
-4. **Register MCP Tool** in `jadx_mcp_server.py`:
-```python
-@mcp.tool()
-async def my_tool(param: str):
-    return await tools.my_tool(param)
-```
-
----
-
-## JADX API Integration
-
-### Accessing Decompiled Code
-```java
-JadxWrapper wrapper = mainWindow.getWrapper();
-JavaClass cls = wrapper.searchJavaClassByFullName("com.example.MainActivity");
-String source = cls.getCode();
-```
-
-### Accessing Resources
-```java
-ResourceFile manifest = wrapper.getResources().get(0); // AndroidManifest.xml
-String content = manifest.loadContent().getText().getCodeStr();
-```
-
-### Accessing Debugger
-```java
-DebuggerController debugger = mainWindow.getDebuggerPanel().getController();
-List<StackFrame> stack = debugger.getStack();
-```
+This keeps Java route surface and MCP tool surface aligned.

--- a/docs/python-api.md
+++ b/docs/python-api.md
@@ -1,696 +1,143 @@
 # Python Module Reference
 
-Complete reference for the JADX-MCP-Server Python codebase.
+This page documents the current Python MCP server modules and behavior.
 
-## Module: `jadx_mcp_server.py`
+## `jadx_mcp_server.py`
 
-Main entry point for the MCP server.
+Main MCP entry point:
 
-### Overview
+- Initializes `FastMCP`
+- Registers all tools from `src/server/tools/*`
+- Parses CLI args:
+  - `--http`
+  - `--host`
+  - `--port`
+  - `--jadx-host`
+  - `--jadx-port`
+- Runs connectivity health check
+- Starts stdio or HTTP transport
 
-This module initializes the FastMCP server and registers all MCP tools. It handles:
-- Command-line argument parsing
-- Server configuration
-- Health check validation
-- Tool registration
-- Server startup
+### Current registered tool count
 
-### Command-Line Arguments
+`32` tools.
 
-```python
-parser = argparse.ArgumentParser("MCP Server for Jadx")
-parser.add_argument("--http", help="Serve MCP Server over HTTP stream", action="store_true", default=False)
-parser.add_argument("--host", help="Host interface to bind for --http (default: 127.0.0.1)", default="127.0.0.1", type=str)
-parser.add_argument("--port", help="Port for --http (default: 8651)", default=8651, type=int)
-parser.add_argument("--jadx-host", help="JADX AI MCP Plugin host (default: 127.0.0.1)", default="127.0.0.1", type=str)
-parser.add_argument("--jadx-port", help="JADX AI MCP Plugin port (default: 8650)", default=8650, type=int)
-```
+## `src/server/config.py`
 
-### Usage Examples
+Responsibilities:
 
-```bash
-# Standard stdio mode (for Claude Desktop)
-uv run jadx_mcp_server.py
+- Tracks `JADX_HOST`, `JADX_PORT`, `JADX_HTTP_BASE`
+- Performs HTTP requests to plugin routes via `httpx`
+- Uses `trust_env=False`
+- Handles:
+  - HTTP status errors
+  - timeouts
+  - connect errors
+  - text fallback
 
-# HTTP mode (for remote/web clients)
-uv run jadx_mcp_server.py --http --port 8651
+Important behavior:
 
-# Custom JADX plugin port
-uv run jadx_mcp_server.py --jadx-port 8652
-```
+- If plugin returns non-JSON text, helper returns:
+  - `{"response": "<text>"}`
 
-### Function: `main()`
+## `src/PaginationUtils.py`
 
-**Description**: Initializes and runs the MCP server.
+Provides generic pagination wrapper:
 
-**Flow**:
-1. Parse command-line arguments
-2. Configure JADX plugin connection
-3. Display banner
-4. Perform health check
-5. Start appropriate transport (stdio or HTTP)
+- Parameter validation (`offset`, `count`)
+- Endpoint request with additional params
+- Standardized result:
 
-**Code**:
-```python
-def main():
-    parser = argparse.ArgumentParser("MCP Server for Jadx")
-    # ... argument setup ...
-    args = parser.parse_args()
-
-    # Configure
-    config.set_jadx_port(args.jadx_port)
-
-    # Health check
-    print(jadx_mcp_server_banner())
-    result = config.health_ping()
-    print(f"Health check result: {result}")
-
-    # Run server
-    if args.http:
-        mcp.run(transport="streamable-http", port=args.port)
-    else:
-        mcp.run()
-```
-
----
-
-## Module: `src.server.config`
-
-Configuration and HTTP client management for communicating with the JADX plugin.
-
-### Global Configuration
-
-```python
-JADX_HOST: str = "127.0.0.1"
-JADX_PORT: int = 8650  # Default plugin port
-JADX_HTTP_BASE: str = f"http://{JADX_HOST}:{JADX_PORT}"
-```
-
-### Function: `set_jadx_host(host: str) -> None`
-
-**Description**: Updates the JADX plugin host configuration.
-
-**Parameters**:
-- `host` (str): IP address or hostname of the JADX AI MCP plugin
-
-### Function: `set_jadx_port(port: int) -> None`
-
-**Description**: Updates the JADX plugin port configuration.
-
-**Parameters**:
-- `port` (int): TCP port where JADX AI MCP plugin listens
-
-**Side Effects**: Updates global `JADX_PORT` and `JADX_HTTP_BASE`
-
-**Example**:
-```python
-set_jadx_host("192.168.1.100")
-set_jadx_port(8652)
-# Now all requests go to http://192.168.1.100:8652
-```
-
-### Function: `health_ping() -> Union[str, Dict[str, Any]]`
-
-**Description**: Checks if JADX plugin is reachable.
-
-**Returns**:
-- Success: `"OK"` string
-- Failure: `{"error": "<error message>"}`
-
-**Timeout**: 60 seconds
-
-**Example**:
-```python
-result = health_ping()
-if isinstance(result, str):
-    print("Plugin is healthy")
-else:
-    print(f"Health check failed: {result['error']}")
-```
-
-### Function: `get_from_jadx(endpoint: str, params: Dict[str, Any] = {}) -> Union[str, Dict[str, Any]]`
-
-**Description**: Generic async HTTP GET request to JADX plugin.
-
-**Parameters**:
-- `endpoint` (str): API endpoint path (e.g., "class-source", "manifest")
-- `params` (dict): Query parameters for the request
-
-**Returns**:
-- Success: Parsed JSON dict or `{"response": text}` if not JSON
-- Failure: `{"error": "<error message>"}`
-
-**Security Feature**:
-- Uses `trust_env=False` on the `httpx.AsyncClient` to prevent system proxy interference (e.g. proxying internal requests meant for `127.0.0.1`).
-
-**Timeout**: 60 seconds
-
-**Error Handling**:
-- HTTP errors → Returns error dict with status code
-- Connection errors → Returns error dict with exception message
-- JSON decode errors → Returns text wrapped in dict
-
-**Example**:
-```python
-# Get class source
-result = await get_from_jadx("class-source", {"class_name": "com.example.MainActivity"})
-
-if "error" not in result:
-    print(result["source"])
-else:
-    print(f"Error: {result['error']}")
-```
-
----
-
-## Module: `src.PaginationUtils`
-
-Reusable pagination framework for handling large datasets.
-
-### Class: `PaginationUtils`
-
-**Description**: Utility class for consistent pagination across all tools.
-
-**Constants**:
-```python
-DEFAULT_PAGE_SIZE = 100
-MAX_PAGE_SIZE = 10000
-MAX_OFFSET = 1000000
-```
-
-### Method: `validate_pagination_params(offset: int, count: int) -> tuple[int, int]`
-
-**Description**: Validates and normalizes pagination parameters.
-
-**Parameters**:
-- `offset` (int): Requested starting offset (can be negative or excessive)
-- `count` (int): Requested item count (can be negative or excessive)
-
-**Returns**: `(validated_offset, validated_count)` tuple
-
-**Validation Logic**:
-- Clamps offset to [0, MAX_OFFSET]
-- Clamps count to [0, MAX_PAGE_SIZE]
-
-**Example**:
-```python
-# Input: Invalid values
-offset, count = PaginationUtils.validate_pagination_params(-10, 50000)
-
-# Output: (0, 10000)
-# Negative offset becomes 0
-# Excessive count clamped to MAX_PAGE_SIZE
-```
-
-### Method: `get_paginated_data(...) -> Union[Dict[str, Any], str]`
-
-**Description**: Generic pagination handler for all JADX endpoints.
-
-**Parameters**:
-- `endpoint` (str): JADX API endpoint
-- `offset` (int): Starting index (default: 0)
-- `count` (int): Items to return (default: 0 = all)
-- `additional_params` (dict): Extra query parameters
-- `data_extractor` (Callable): Function to extract items from response
-- `item_transformer` (Callable): Optional per-item transformation
-- `fetch_function` (Callable): Async function to fetch data (typically `get_from_jadx`)
-
-**Returns**: Standardized pagination response
-
-**Error Handling (Early Return)**:
-If the `fetch_function` returns an error dictionary (i.e. containing an `"error"` key), the pagination utility will immediately return the error object. This ensures API errors are properly propagated instead of swallowed into an empty list.
-
-**Response Format**:
-```python
+```json
 {
-    "type": "paginated-list",
-    "items": [...],  # Extracted/transformed items
-    "pagination": {
-        "total": 1500,      # Total items available
-        "offset": 100,      # Current offset
-        "limit": 100,       # Items per page
-        "count": 100,       # Items in this response
-        "has_more": True,   # More items available?
-        "next_offset": 200, # Next page offset
-        "prev_offset": 0    # Previous page offset
-    }
+  "type": "paginated-list",
+  "items": [],
+  "pagination": {
+    "total": 0,
+    "offset": 0,
+    "limit": 0,
+    "count": 0,
+    "has_more": false
+  }
 }
 ```
 
-**Example**:
-```python
-result = await PaginationUtils.get_paginated_data(
-    endpoint="all-classes",
-    offset=0,
-    count=50,
-    data_extractor=lambda resp: resp.get("classes", []),
-    fetch_function=get_from_jadx
-)
+## Tool Modules
 
-print(f"Got {result['pagination']['count']} of {result['pagination']['total']} classes")
-for class_name in result['items']:
-    print(class_name)
+### `src/server/tools/class_tools.py`
 
-if result['pagination']['has_more']:
-    # Fetch next page
-    next_result = await PaginationUtils.get_paginated_data(
-        endpoint="all-classes",
-        offset=result['pagination']['next_offset'],
-        count=50,
-        data_extractor=lambda resp: resp.get("classes", []),
-        fetch_function=get_from_jadx
-    )
+Class and project structure tools:
+
+- `fetch_current_class`
+- `get_selected_text`
+- `get_class_source`
+- `get_all_classes`
+- `get_methods_of_class`
+- `get_fields_of_class`
+- `get_smali_of_class`
+- `get_main_application_classes_names`
+- `get_main_application_classes_code`
+- `get_main_activity_class`
+- `get_package_tree`
+- `get_cache_stats`
+- `clear_cache`
+
+### `src/server/tools/search_tools.py`
+
+Search tools:
+
+- `get_method_by_name(class_name, method_name, method_signature=None)`
+- `search_method_by_name(method_name)`
+- `search_classes_by_keyword(search_term, package="", search_in="code", offset=0, count=20)`
+
+Includes search progress polling (`/search-progress`) and optional MCP progress reporting.
+
+### `src/server/tools/resource_tools.py`
+
+Resource/manifest tools:
+
+- `get_android_manifest`
+- `get_manifest_component(component_type, only_exported=False)`
+- `get_strings`
+- `get_all_resource_file_names`
+- `get_resource_file`
+
+### `src/server/tools/refactor_tools.py`
+
+Refactor tools:
+
+- `rename_class(class_name, new_name)`
+- `rename_method(method_name, new_name, class_name=None, method_signature=None)`
+- `rename_field(class_name, field_name, new_name)`
+- `rename_package(old_package_name, new_package_name)`
+- `rename_variable(class_name, method_name, variable_name, new_name, reg=None, ssa=None)`
+
+### `src/server/tools/xrefs_tools.py`
+
+Xref tools:
+
+- `get_xrefs_to_class`
+- `get_xrefs_to_method`
+- `get_xrefs_to_field`
+
+### `src/server/tools/debug_tools.py`
+
+Debug tools:
+
+- `debug_get_stack_frames`
+- `debug_get_threads`
+- `debug_get_variables`
+
+## Response Caveats
+
+Some Java routes still emit plain text (`ctx.result`) rather than JSON.  
+For those routes, MCP consumers should handle:
+
+```json
+{ "response": "..." }
 ```
 
----
+This is expected for several current endpoints (for example method/class listing style routes).
 
-## Module: `src.server.tools.class_tools`
+## Versioning Note
 
-Tools for analyzing decompiled Java classes.
-
-### Function: `fetch_current_class() -> dict`
-
-**MCP Tool**: `fetch_current_class`
-
-**Description**: Fetches the currently selected class in JADX-GUI editor.
-
-**Returns**:
-```python
-{
-    "className": "com.example.MainActivity",
-    "package": "com.example",
-    "source": "public class MainActivity extends Activity { ... }"
-}
-```
-
-**Use Cases**:
-- Quick context gathering
-- AI-assisted code review of selected class
-- Starting point for deeper analysis
-
-**Example Prompt**:
-```
-Fetch the currently selected class and perform a security audit
-```
-
-### Function: `get_class_source(class_name: str) -> dict`
-
-**MCP Tool**: `get_class_source`
-
-**Description**: Retrieves complete decompiled source for a specific class.
-
-**Parameters**:
-- `class_name` (str): Fully qualified class name
-
-**Returns**:
-```python
-{
-    "className": "com.example.utils.CryptoHelper",
-    "source": "package com.example.utils;\n\npublic class CryptoHelper { ... }",
-    "exists": True
-}
-```
-
-**Error Response**:
-```python
-{
-    "error": "CLASS_NOT_FOUND",
-    "message": "Class com.example.Unknown not found"
-}
-```
-
-**Example**:
-```python
-result = await get_class_source("com.example.MainActivity")
-if result.get("exists"):
-    print(result["source"])
-```
-
-### Function: `get_all_classes(offset: int = 0, count: int = 0) -> dict`
-
-**MCP Tool**: `get_all_classes`
-
-**Description**: Returns paginated list of all classes in the APK.
-
-**Parameters**:
-- `offset` (int): Starting index (default: 0)
-- `count` (int): Number to return (0 = all, default: 0)
-
-**Returns**: Paginated response with class names
-
-**Performance Notes**:
-- Small APKs (<1000 classes): Use count=0 to get all
-- Large APKs (>1000 classes): Use pagination with count=100-500
-
-**Example**:
-```python
-# Get first 200 classes
-result = await get_all_classes(offset=0, count=200)
-
-print(f"Total classes in APK: {result['pagination']['total']}")
-for class_name in result['items']:
-    print(class_name)
-
-# Get next 200
-if result['pagination']['has_more']:
-    next_batch = await get_all_classes(
-        offset=result['pagination']['next_offset'],
-        count=200
-    )
-```
-
-### Function: `get_smali_of_class(class_name: str) -> dict`
-
-**MCP Tool**: `get_smali_of_class`
-
-**Description**: Retrieves Smali (Dalvik bytecode) representation of a class.
-
-**Parameters**:
-- `class_name` (str): Fully qualified class name
-
-**Returns**:
-```python
-{
-    "className": "com.example.Native",
-    "smali": ".class public Lcom/example/Native;\n.super Ljava/lang/Object;\n...",
-    "format": "smali"
-}
-```
-
-**Use Cases**:
-- Low-level bytecode analysis
-- Native method investigation
-- Obfuscation pattern detection
-- Instruction-level optimization analysis
-
-**Example Prompt**:
-```
-Get the smali for NativeLib class and identify anti-debugging checks
-```
-
----
-
-## Module: `src.server.tools.search_tools`
-
-Full-text search capabilities across decompiled code.
-
-### Function: `search_classes_by_keyword(search_term: str, search_in: str = "all", package: str = "", offset: int = 0, count: int = 20) -> dict`
-
-**MCP Tool**: `search_classes_by_keyword`
-
-**Description**: Performs full-text search across all class source code with scope filters.
-
-**Parameters**:
-- `search_term` (str): Keyword to search for
-- `search_in` (str): Search scope: "all", "code", "comments", or "strings" (default: "all")
-- `package` (str): Limit search to specific package (default: "")
-- `offset` (int): Pagination offset (default: 0)
-- `count` (int): Results per page (default: 20)
-
-**Returns**: Paginated search results
-
-**Search Behavior**:
-- Case-sensitive matching
-- Searches in decompiled Java source
-- Returns classes containing the term
-- Includes match count per class
-
-**Performance**:
-- Broad terms ("a", "get") → Slow, many results
-- Specific terms ("AES", "password") → Fast, focused results
-
-**Example**:
-```python
-# Find all WebView usage
-results = await search_classes_by_keyword("WebView", offset=0, count=50)
-
-for item in results['items']:
-    print(f"Found in: {item['className']}")
-    print(f"Matches: {item['matches']}")
-    print(f"Preview: {item['preview']}")
-```
-
----
-
-## Module: `src.server.tools.xrefs_tools`
-
-Cross-reference analysis for tracking code usage.
-
-### Function: `get_xrefs_to_method(class_name: str, method_name: str, offset: int = 0, count: int = 20) -> dict`
-
-**MCP Tool**: `get_xrefs_to_method`
-
-**Description**: Finds all locations where a method is invoked.
-
-**Parameters**:
-- `class_name` (str): Class containing the method
-- `method_name` (str): Method name (can include signature)
-- `offset` (int): Pagination offset (default: 0)
-- `count` (int): Results per page (default: 20)
-
-**Returns**:
-```python
-{
-    "targetMethod": "encrypt",
-    "targetClass": "com.example.crypto.AES",
-    "references": [
-        {
-            "fromClass": "com.example.FileManager",
-            "fromMethod": "void saveSecure(File)",
-            "lineNumber": 120,
-            "code": "String encrypted = aes.encrypt(data);"
-        },
-        # ... more references
-    ],
-    "pagination": { ... }
-}
-```
-
-**Use Cases**:
-- Data flow analysis
-- Impact assessment for refactoring
-- Vulnerability tracking
-- Understanding code relationships
-
-**Example Workflow**:
-```python
-# 1. Find suspicious crypto method
-crypto_methods = await search_method_by_name("decrypt")
-
-# 2. For each method, get xrefs
-for method in crypto_methods['results']:
-    xrefs = await get_xrefs_to_method(
-        method['className'],
-        method['methodName'],
-        offset=0,
-        count=100
-    )
-
-    # 3. Analyze each call site
-    for ref in xrefs['references']:
-        source = await get_class_source(ref['fromClass'])
-        # Analyze if sensitive data is passed to decrypt
-```
-
----
-
-## Module: `src.server.tools.refactor_tools`
-
-Code refactoring capabilities for improving readability.
-
-### Function: `rename_class(class_name: str, new_name: str) -> dict`
-
-**MCP Tool**: `rename_class`
-
-**Description**: Renames a class and updates all references.
-
-**Parameters**:
-- `class_name` (str): Current fully qualified class name
-- `new_name` (str): New class name (without package)
-
-**Returns**:
-```python
-{
-    "oldName": "com.example.a",
-    "newName": "com.example.CryptoHelper",
-    "success": True,
-    "affectedFiles": 12  # Number of files updated
-}
-```
-
-**Behavior**:
-- Updates class declaration
-- Updates all import statements
-- Updates all instantiations
-- Updates all references throughout codebase
-
-**Best Practices**:
-1. Start with leaf classes (no dependencies)
-2. Use descriptive names based on functionality
-3. Keep package structure intact
-4. Rename systematically (not randomly)
-
-**Example Workflow**:
-```python
-# Systematic deobfuscation
-# 1. Identify obfuscated class
-source = await get_class_source("com.example.a")
-
-# 2. Analyze functionality
-# (AI determines it's a crypto helper)
-
-# 3. Rename
-result = await rename_class("com.example.a", "CryptoHelper")
-
-print(f"Updated {result['affectedFiles']} files")
-```
-
----
-
-## Module: `src.server.tools.debug_tools`
-
-Runtime analysis during debugging sessions.
-
-### Function: `debug_get_variables() -> dict`
-
-**MCP Tool**: `debug_get_variables`
-
-**Description**: Retrieves local and instance variables when debugger is paused.
-
-**Requirements**:
-- JADX debugger must be active
-- Execution must be suspended at a breakpoint
-
-**Returns**:
-```python
-{
-    "locals": [
-        {
-            "name": "password",
-            "type": "String",
-            "value": "secret123"
-        },
-        {
-            "name": "isValid",
-            "type": "boolean",
-            "value": "true"
-        }
-    ],
-    "fields": [
-        {
-            "name": "mContext",
-            "type": "Context",
-            "value": "android.app.ContextImpl@abc123"
-        }
-    ]
-}
-```
-
-**Use Cases**:
-- Runtime security analysis
-- Understanding execution flow
-- Identifying sensitive data in memory
-- Debugging complex logic
-
-**Example Analysis**:
-```python
-# Set breakpoint at login method
-# When hit, get variables
-vars = await debug_get_variables()
-
-# Check for security issues
-for local in vars['locals']:
-    if 'password' in local['name'].lower():
-        if local['type'] == 'String':
-            print("⚠️  Password stored as String (security risk)")
-            print("   Recommendation: Use char[] and clear after use")
-```
-
----
-
-## Error Handling
-
-All tools follow consistent error handling:
-
-### Success Response
-```python
-{
-    "success": True,
-    "data": { ... },
-    "metadata": {
-        "timestamp": "2025-12-30T00:00:00Z",
-        "tool": "get_class_source"
-    }
-}
-```
-
-### Error Response
-```python
-{
-    "error": "CLASS_NOT_FOUND",
-    "message": "Class com.example.Unknown not found",
-    "details": "..."
-}
-```
-
-### Common Error Codes
-
-| Code | Description | Resolution |
-|------|-------------|------------|
-| `CLASS_NOT_FOUND` | Class doesn't exist | Verify class name is fully qualified |
-| `METHOD_NOT_FOUND` | Method doesn't exist | Check method signature |
-| `NO_APK_LOADED` | No APK in JADX | Load an APK file |
-| `DEBUGGER_NOT_ACTIVE` | Debugger not running | Start JADX debugger |
-| `CONNECTION_ERROR` | Can't reach plugin | Check plugin is running |
-| `TIMEOUT` | Operation took >60s | Use pagination or smaller requests |
-
----
-
-## Type Hints
-
-All functions use Python type hints:
-
-```python
-from typing import Dict, List, Any, Union, Optional
-
-async def get_class_source(class_name: str) -> Dict[str, Any]:
-    ...
-
-async def search_classes_by_keyword(
-    search_term: str,
-    offset: int = 0,
-    count: int = 20
-) -> Dict[str, Any]:
-    ...
-```
-
----
-
-## Testing
-
-Example test structure:
-
-```python
-import pytest
-from src.server.tools import class_tools
-
-@pytest.mark.asyncio
-async def test_get_class_source():
-    result = await class_tools.get_class_source("com.example.MainActivity")
-    assert "source" in result
-    assert result["className"] == "com.example.MainActivity"
-
-@pytest.mark.asyncio  
-async def test_class_not_found():
-    result = await class_tools.get_class_source("com.example.NonExistent")
-    assert "error" in result
-    assert result["error"] == "CLASS_NOT_FOUND"
-```
-
----
-
-## Next Steps
-
-- [Java Plugin Reference](java-api.md) - Plugin-side documentation
-- [API Reference](api-reference.md) - Tool usage examples
-- [Architecture](architecture.md) - System design details
+Python requirement is aligned at `>=3.10` for both script execution and package metadata.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -62,10 +62,11 @@ uv pip install -r requirements.txt
 ```
 
 ### "Python Version Mismatch"
-**Error**: Syntax errors or import errors
+**Error**: install/runtime failure related to Python requirements
 
 **Solution**:
-Ensure Python 3.10+:
+Use Python 3.10+ for both script run and package install modes.
+
 ```bash
 python3 --version
 ```

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,316 +1,75 @@
 # User Guide
 
-Complete guide to using JADX-AI-MCP for Android reverse engineering with AI assistance.
+## Standard Workflow
 
-## Getting Started
+1. Open JADX-GUI and load APK
+2. Start MCP server (`uv run jadx_mcp_server.py`)
+3. Connect MCP client
+4. Start with discovery tools:
+   - `get_package_tree()`
+   - `get_main_activity_class()`
+   - `get_all_classes(...)`
 
-### Initial Setup
+## Useful Prompt Patterns
 
-1. **Launch JADX-GUI** with an APK loaded
-2. **Start your LLM client** (Claude Desktop, Cherry Studio, or LM Studio)
-3. **Verify connection** - Look for the hammer icon (🔨) in your LLM client
+### Initial triage
 
-### Basic Workflow
-
-```mermaid
-graph LR
-    A[Load APK] --> B[Select Class]
-    B --> C[Ask AI]
-    C --> D[Review Results]
-    D --> E{More Analysis?}
-    E -->|Yes| B
-    E -->|No| F[Export/Save]
+```text
+Get package tree, main activity, and main application class names.
+Then summarize likely entry points and sensitive modules.
 ```
 
-## Core Features
+### Security hunt
 
-### 1. Class Analysis
-
-#### Fetching Current Class
-
-Select any class in JADX-GUI and ask:
-
-```
-Fetch the currently selected class and analyze it for security issues
+```text
+Search for WebView, crypto, auth, and manifest risks.
+Return high-risk findings first with class names.
 ```
 
-**What happens:**
-- Plugin captures selected class
-- Sends decompiled source to LLM
-- AI performs SAST (Static Application Security Testing)
-- Returns vulnerability report
+### Refactor/deobfuscate
 
-#### Get Specific Class
-
-```
-Get the source code for class com.example.app.MainActivity
+```text
+Suggest better names for obfuscated classes and fields,
+then apply safe renames incrementally.
 ```
 
-**Use cases:**
-- Analyze specific components
-- Compare class implementations
-- Track obfuscated classes
+## Search Usage
 
-### 2. Code Search
+Use `search_classes_by_keyword` with real supported scopes:
 
-#### Search by Method Name
-
-```
-Search for all methods named "encrypt" across the application
-```
-
-**Returns:**
-- All classes containing matching methods
-- Method signatures
-- Locations in codebase
-
-#### Search by Keyword
-
-```
-Search for classes containing the keyword "password"
-```
-
-**Useful for:**
-- Finding credential handling code
-- Locating encryption routines
-- Identifying API endpoints
-
-#### Scoped Search
-
-```
-Search for "http://" only in strings, within the "com.example.network" package
-```
-
-**Scope options:**
-- `all` (default)
+- `class`
+- `method`
+- `field`
 - `code`
-- `comments`
-- `strings`
+- `comment`
 
-#### Pagination Support
+Examples:
 
-For large results:
-
-```
-Search for classes containing "crypto" with pagination offset=0 count=20
-```
-
-### 3. Resource Analysis
-
-#### Android Manifest
-
-```
-Analyze the AndroidManifest.xml for security issues
+```text
+search_classes_by_keyword(search_term="password", search_in="code")
+search_classes_by_keyword(search_term="retrofit", search_in="class,method")
+search_classes_by_keyword(search_term="token", package="com.example.auth", search_in="field,code")
 ```
 
-**Checks:**
-- Dangerous permissions
-- Exported components
-- Intent filters
-- Debug flags
+Default `search_in` is `code`.
 
-#### Specific Manifest Components
+## Refactor Usage Notes
 
-```
-Get all exported Activities from the Manifest
-```
+- `rename_class(class_name, new_name)` is class-scoped.
+- `rename_field(class_name, field_name, new_name)` is class-scoped.
+- `rename_method(method_name, new_name, class_name=None, method_signature=None)` supports optional class scoping.
 
-**Use cases:**
-- Deep dive into Specific Components (Activities, Services, Receivers, Providers)
-- Finding unprotected endpoints
+When renaming methods in obfuscated apps, pass both `class_name` and `method_signature` where possible.
 
-#### Strings Extraction
+## Debug Session Tips
 
-```
-Get all strings from strings.xml files
-```
+For debugger tools (`debug_get_stack_frames`, `debug_get_threads`, `debug_get_variables`):
 
-**Use cases:**
-- Find hardcoded secrets
-- Identify API endpoints
-- Extract user-facing text
+- Ensure process is paused on a breakpoint.
+- Pull stack + variables together to understand execution context.
 
-#### Resource Files
+## Large APK Strategy
 
-```
-List all resource files in the APK
-```
-
-```
-Get the content of res/layout/activity_main.xml
-```
-
-### 4. Cross-Reference Analysis (Xrefs)
-
-#### Find Class References
-
-```
-Find all references to class com.example.crypto.AES
-```
-
-**Shows:**
-- Where class is instantiated
-- Constructor calls
-- Static method invocations
-
-#### Find Method References
-
-```
-Find all references to method encryptData in class CryptoHelper
-```
-
-**Reveals:**
-- Call sites
-- Usage patterns
-- Data flow
-
-#### Find Field References
-
-```
-Find all references to field API_KEY in class Config
-```
-
-**Identifies:**
-- Read operations
-- Write operations
-- Potential leaks
-
-### 5. Refactoring
-
-#### Rename Class
-
-```
-Rename class a.b.c to com.example.crypto.AESEncryption
-```
-
-**Benefits:**
-- Improves code readability
-- Aids understanding
-- Simplifies analysis
-
-#### Rename Method
-
-```
-Rename method a() in class Helper to decryptPassword()
-```
-
-#### Rename Variable
-
-```
-Rename variable 'str' locally inside method 'loadConfig' to 'apiKey'
-```
-
-**Benefits:**
-- Simplifies complex function analysis
-- Cleans up minified code
-
-#### Rename Package
-
-```
-Rename package a.b to com.example.utils
-```
-
-**Batch operation:** Renames all classes in the package
-
-### 6. Debugging Support
-
-#### Stack Frames
-
-```
-Get current stack frames from the debugger
-```
-
-**Requirements:**
-- JADX debugger must be active
-- Breakpoint hit
-
-#### Thread Analysis
-
-```
-Get all threads from the debugged process
-```
-
-**Shows:**
-- Thread names
-- Thread states
-- Thread priorities
-
-#### Variable Inspection
-
-```
-Get variables from the current debugging context
-```
-
-**Displays:**
-- Local variables
-- Instance variables
-- Variable values
-
-## Advanced Usage
-
-### Security Analysis Workflows
-
-#### Vulnerability Scanning
-
-```
-Perform a comprehensive security analysis:
-1. Get the AndroidManifest and check for dangerous permissions
-2. Search for classes containing "WebView"
-3. Analyze WebView usage for JavaScript injection vulnerabilities
-4. Search for hardcoded credentials in all classes
-5. Provide a summary report
-```
-
-#### Data Flow Analysis
-
-```
-Trace data flow for sensitive information:
-1. Find all references to getUserPassword method
-2. For each reference, get the calling method's source
-3. Analyze how password is handled
-4. Identify potential security issues
-```
-
-### Obfuscation Analysis
-
-#### Deobfuscation Strategy
-
-```
-Help me deobfuscate this app:
-1. Get main application classes
-2. Identify naming patterns (a.b.c vs meaningful names)
-3. Suggest descriptive names based on functionality
-4. Rename classes systematically
-```
-
-#### Pattern Recognition
-
-```
-Analyze the obfuscation technique:
-1. Get list of all classes
-2. Identify obfuscation patterns
-3. Determine obfuscator type (ProGuard/R8/DexGuard)
-4. Suggest deobfuscation approach
-```
-
-### Large APK Analysis
-
-#### Pagination Strategy
-
-```
-Analyze all classes efficiently:
-1. Get total class count
-2. Fetch classes in batches of 50
-3. For each batch, identify interesting classes
-4. Deep dive into flagged classes
-```
-
-#### Selective Analysis
-
-```
-Focus on high-risk components:
-1. Get main activity class
-2. Get all application package classes
-3. Search for network-related classes
-4. Analyze only crypto and auth classes
-```
+- Use pagination for broad scans (`offset`/`count`).
+- Narrow package scope before deep source extraction.
+- Use cache tools (`get_cache_stats`, `clear_cache`) when switching APKs.


### PR DESCRIPTION
## Why

The ReadTheDocs pages had drifted from the actual MCP tool surface. Several documented signatures no longer matched the tools the server registers, so the reference pages were actively misleading for anyone writing client-side calls - most importantly `rename_method`, which gained `class_name` and `method_signature` in v6.4.1 (#106 / #103) while the docs still showed the old three-argument form with the arguments in the wrong order.

## Signature corrections

Each of these was verified against the **live registered tool schemas** from a running server instance, not transcribed by hand:

| Tool | Documented now |
|---|---|
| `rename_method` | `(method_name, new_name, class_name=None, method_signature=None)` |
| `rename_variable` | `(class_name, method_name, variable_name, new_name, reg=None, ssa=None)` |
| `search_classes_by_keyword` | `(search_term, package='', search_in='code', offset=0, count=20)` |
| `get_method_by_name` | `(class_name, method_name, method_signature=None)` |
| `get_xrefs_to_method` | `(class_name, method_name, offset=0, count=20)` |

The previous `rename_method(class_name, method_name, new_name)` form would fail for every caller who copied it, since `method_name` is the first positional parameter and `class_name` is optional.

`search_classes_by_keyword` also had `search_in` documented with a default of `"all"` and in the wrong position; the real default is `"code"`.

## Other changes

- Condensed the reference pages. They had accumulated substantial duplicated prose and aspirational examples describing tools that are not shipped.
- Clarified that the Python floor is **3.10** for both script mode and packaged install mode. (Related: zinja-coder/jadx-mcp-server#63 fixes the `pyproject.toml` side of this, which still declared `>=3.13`.)
- Added a changelog entry recording the sync.

Net diff is +506 / −2426 across 10 pages, so this is mostly removal of stale and duplicated content rather than new writing.