### PR TITLE
docs: credit v6.4.1 issue reporters as contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,44 @@ Thanks to these wonderful people for their contributions ⭐
       </a>
     </td>
   </tr>
+  <tr align="center">
+    <td>
+      <a href="https://github.com/LYC-Android">
+        <img src="https://avatars.githubusercontent.com/u/18358825?v=4" width="30px;" alt=""/>
+        <br /><sub><b>LYC-Android</b></sub>
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/zbhello">
+        <img src="https://avatars.githubusercontent.com/u/122980705?v=4" width="30px;" alt=""/>
+        <br /><sub><b>zbhello</b></sub>
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/1yearning1">
+        <img src="https://avatars.githubusercontent.com/u/297883149?v=4" width="30px;" alt=""/>
+        <br /><sub><b>1yearning1</b></sub>
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/mhsjzsq">
+        <img src="https://avatars.githubusercontent.com/u/116739454?v=4" width="30px;" alt=""/>
+        <br /><sub><b>mhsjzsq</b></sub>
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/darkblack1234">
+        <img src="https://avatars.githubusercontent.com/u/139411545?v=4" width="30px;" alt=""/>
+        <br /><sub><b>darkblack1234</b></sub>
+      </a>
+    </td>
+    <td>
+      <a href="https://github.com/Merrg1n">
+        <img src="https://avatars.githubusercontent.com/u/22628584?v=4" width="30px;" alt=""/>
+        <br /><sub><b>Merrg1n</b></sub>
+      </a>
+    </td>
+  </tr>
 </table>
 
 


### PR DESCRIPTION
## Why

Every fix in v6.4.1 came from a community bug report — there were no maintainer-discovered bugs in this release. Several of those reports went well beyond describing a symptom and did the root-cause analysis outright, which is the kind of work the contributors table exists to recognise.

## Who and what they contributed

| Contributor | Issue | What the report actually provided |
|---|---|---|
| [LYC-Android](https://github.com/LYC-Android) | #103 | Observed that `rename_field` and `rename_class` both accept `class_name` while `rename_method` does not, quantified the failure rate (~55% vs ~95% on obfuscated batch renames), and supplied the parameter-threading fix across all three layers |
| [mhsjzsq](https://github.com/mhsjzsq) | #106 | Pinpointed `MethodInfo.getShortId()` returning the pre-rename name while JADX displays the alias, named the exact file and method, and proposed `makeShortId` as the fix |
| [Merrg1n](https://github.com/Merrg1n) | server #60 | Traced `show_banner=False` back to PR #51 and found it had been silently dropped in merge `605429d` — turning an apparent new bug into a known regression |
| [1yearning1](https://github.com/1yearning1) | #105 | Supplied the full stack trace naming `ResContainer.getText(ResContainer.java:64)` and the exact failing line in `ResourceRoutes` |
| [darkblack1234](https://github.com/darkblack1234) | server #59 | Gave an exact repro (Spring Boot jar, `BOOT-INF/classes/application.properties`) and correctly predicted the bug would generalize to other `ResourceFile`-backed resources |
| [zbhello](https://github.com/zbhello) | #104 | Reported the Codex CLI failure and noted Claude Code was unaffected — the observation that isolated it to stdio transport |

## Change

Adds a second `<tr>` to the existing contributors table rather than extending the first row, which was already 17 wide and would have become 23 columns on a single line.

Markup validated: balanced `<tr>`/`<td>` tags, 23 entries total, and all six avatar and profile URLs return HTTP 200.
